### PR TITLE
fix(ltk_texture)!: make 'intel-tex' feature no longer default

### DIFF
--- a/crates/ltk_texture/Cargo.toml
+++ b/crates/ltk_texture/Cargo.toml
@@ -25,7 +25,7 @@ intel_tex_2 = { version = "0.5.0", optional = true }
 
 
 [features]
-default = ["intel-tex"]
+default = []
 intel-tex = ["dep:intel_tex_2"]
 
 [dev-dependencies]


### PR DESCRIPTION
(breaking change)

making this opt-in means wasm/other atypical build targets can consume the top level crate easier
