### PR TITLE
fix (ltk_file): more reasonable order for file magic patterns

### DIFF
--- a/crates/ltk_file/src/pattern.rs
+++ b/crates/ltk_file/src/pattern.rs
@@ -2,7 +2,7 @@ use super::LeagueFileKind;
 
 pub static LEAGUE_FILE_MAGIC_BYTES: &[LeagueFilePattern] = &[
     // Fixed headers have highest prio since they have the most confidence
-    LeagueFilePattern::from_bytes(b"r3d2ammd", LeagueFileKind::Animation),
+    LeagueFilePattern::from_bytes(b"r3d2anmd", LeagueFileKind::Animation),
     LeagueFilePattern::from_bytes(b"r3d2canm", LeagueFileKind::Animation),
     LeagueFilePattern::from_bytes(b"OEGM", LeagueFileKind::MapGeometry),
     LeagueFilePattern::from_bytes(b"PreLoad", LeagueFileKind::Preload),


### PR DESCRIPTION
(also fixed r3d2ammd typo)
we likely need to rethink our patterns for kinds like WwisePackage that are very likely to have false positives, but for now this will improve things