### PR TITLE
fix(ritobin)!: report items the typechecker silently dropped

### DIFF
--- a/crates/ltk_ritobin/src/cst/tree.rs
+++ b/crates/ltk_ritobin/src/cst/tree.rs
@@ -10,7 +10,7 @@ use crate::{
     parse::{
         impls,
         tokenizer::{self, Token},
-        Error, ErrorPropagation, Parser, Span,
+        Error, ErrorPropagation, Parser, Span, TokenKind,
     },
     typecheck::diagnostics::DiagnosticWithSpan,
 };
@@ -129,6 +129,20 @@ pub struct Node {
     /// [`ErrorPropagation`] the parser was using.
     #[cfg_attr(feature = "serde", serde(skip_deserializing))]
     pub errors: ErrorRange,
+}
+
+impl Node {
+    /// Span of the node's opening brace, falling back to the node's own span.
+    ///
+    /// Use this when you want to point a diagnostic at the block opening, or at the node itself if it doesn't have one.
+    pub fn open_brace_span(&self, cst: &Cst) -> Span {
+        self.children
+            .get(cst)
+            .first()
+            .and_then(|c| c.token(cst))
+            .filter(|t| t.kind == TokenKind::LCurly)
+            .map_or(self.span, |t| t.span)
+    }
 }
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/crates/ltk_ritobin/src/typecheck.rs
+++ b/crates/ltk_ritobin/src/typecheck.rs
@@ -27,8 +27,8 @@ mod test {
     };
 
     use crate::{
-        typecheck::diagnostics::{Diagnostic, DiagnosticWithSpan, ItemShape, RootKind},
-        Cst, RitoType,
+        typecheck::diagnostics::{Diagnostic, DiagnosticWithSpan, RootKind},
+        Cst, ItemShape, RitoType,
     };
 
     fn wrap(input: &str) -> String {
@@ -448,6 +448,138 @@ entries: map[hash,embed] = {}
                     }
                 )
             },
+        );
+    }
+
+    #[test]
+    fn a_type_mismatch_blames_the_type_expression_that_set_it() {
+        // the LSP renders `expected_span` as "due to this type expression", so it has to point
+        // at an actual type expression - not at the container's braces, and not at all when the
+        // expectation was not written down anywhere
+        let blamed = |input: &str| {
+            let text = wrap(input);
+            let (_, errs) = Cst::parse(&text).build_bin(&text);
+            errs.into_iter()
+                .find_map(|e| match e.diagnostic {
+                    Diagnostic::TypeMismatch { expected_span, .. } => Some(expected_span),
+                    _ => None,
+                })
+                .expect("expected a TypeMismatch")
+                .map(|span| text[span].to_owned())
+        };
+
+        assert_eq!(
+            blamed(r#"0x1: list[u32] = { "a" }"#).as_deref(),
+            Some("list[u32]")
+        );
+        assert_eq!(
+            blamed(r#"0x1: map[u32,u32] = { "5" = 1 }"#).as_deref(),
+            Some("map[u32,u32]")
+        );
+        assert_eq!(
+            blamed(r#"0x1: option[u32] = { "a" }"#).as_deref(),
+            Some("option[u32]")
+        );
+        // a numeric literal resolved against a hint that takes no number
+        assert_eq!(blamed(r#"0x1: string = 5"#).as_deref(), Some("string"));
+        // listlike components answer to the type that made them components
+        assert_eq!(
+            blamed(r#"0x1: vec3 = { 1, "a", 3 }"#).as_deref(),
+            Some("vec3")
+        );
+        assert_eq!(
+            blamed(r#"0x1: rgba = { 1, "a", 3, 4 }"#).as_deref(),
+            Some("rgba")
+        );
+        // ... and a listlike written as a list item falls back to the container's subtype
+        assert_eq!(
+            blamed(r#"0x1: list[vec3] = { { 1, "a", 3 } }"#).as_deref(),
+            Some("list[vec3]")
+        );
+        // a property name is a hash because it is a property name - no type expression said so
+        assert_eq!(blamed("true: u32 = 3").as_deref(), None);
+    }
+
+    #[test]
+    fn a_wrong_shaped_item_is_underlined_whole() {
+        // a parent rejects the item, not a part of it - from the list's point of view the whole
+        // 'key: u32 = 1' is the mistake, even though '1' on its own would be a fine list item
+        let underlined = |input: &str| {
+            let err = assert_one_err(input, |d| matches!(d, Diagnostic::UnexpectedItem { .. }));
+            wrap(input)[err.span].to_owned()
+        };
+
+        assert_eq!(
+            underlined(r#"0x1: list[u32] = { key: u32 = 1 }"#),
+            "key: u32 = 1"
+        );
+        assert_eq!(
+            underlined(r#"0x1: list[u32] = { 0xdead = 1 }"#),
+            "0xdead = 1"
+        );
+        assert_eq!(
+            underlined(r#"0x1: list[u32] = { "key" = 1 }"#),
+            r#""key" = 1"#
+        );
+        assert_eq!(
+            underlined(r#"0x1: option[u32] = { key: u32 = 1 }"#),
+            "key: u32 = 1"
+        );
+        assert_eq!(underlined(r#"0x1: map[hash,u32] = { 5 }"#), "5");
+    }
+
+    #[test]
+    fn an_unexpected_item_names_the_shape_its_parent_wants() {
+        let is_shape = |d: &Diagnostic| matches!(d, Diagnostic::UnexpectedItem { .. });
+
+        let map = assert_one_err(r#"0x1: map[hash,u32] = { 5 }"#, is_shape);
+        assert_eq!(
+            map.diagnostic.to_string(),
+            "map[hash,u32] takes an entry ('name: type = value')"
+        );
+
+        let class = assert_one_err(
+            r#"
+        name: string = "A"
+        ""
+        flags: u32 = 1
+        "#,
+            is_shape,
+        );
+        assert_eq!(
+            class.diagnostic.to_string(),
+            "embed takes an entry ('name: type = value')"
+        );
+
+        let list = assert_one_err(r#"0x1: list[u32] = { key: u32 = 1 }"#, is_shape);
+        assert_eq!(list.diagnostic.to_string(), "list[u32] takes a value");
+    }
+
+    /// A map entry takes its value type from the map's subtype, but writing it out is allowed -
+    /// it just has to agree with what the map declared.
+    #[test]
+    fn a_map_entry_may_declare_its_value_type() {
+        assert(r#"0x1: map[hash,u32] = { 0xdead: u32 = 1 }"#, |obj| {
+            obj.property(
+                0x1,
+                values::Map::new(
+                    PropertyKind::Hash,
+                    PropertyKind::U32,
+                    vec![(
+                        values::Hash::from(BinHash::from(0xdeadu32)).into(),
+                        values::U32::from(1u32).into(),
+                    )],
+                )
+                .unwrap(),
+            )
+        });
+
+        let err = assert_one_err(r#"0x1: map[hash,u32] = { 0xdead: string = "a" }"#, |d| {
+            matches!(d, Diagnostic::TypeMismatch { .. })
+        });
+        assert_eq!(
+            err.diagnostic.to_string(),
+            "Type mismatch - expected u32, got string"
         );
     }
 

--- a/crates/ltk_ritobin/src/typecheck.rs
+++ b/crates/ltk_ritobin/src/typecheck.rs
@@ -373,6 +373,10 @@ entries: map[hash,embed] = {}
         );
         // points at the `{` the class name should precede, not the whole block
         assert_eq!(err.span.len(), 1);
+        assert_eq!(
+            err.diagnostic.to_string(),
+            "Missing class name - embed values are written 'ClassName { .. }'"
+        );
     }
 
     #[test]
@@ -637,7 +641,7 @@ entries: map[hash,embed] = {}
     /// A key that can't become a hash was dropped silently by `merge_ir`.
     #[test]
     fn a_property_name_that_cannot_be_hashed_is_reported() {
-        assert_one_err(r#"true: u32 = 3"#, |d| {
+        let err = assert_one_err(r#"true: u32 = 3"#, |d| {
             matches!(
                 d,
                 Diagnostic::TypeMismatch {
@@ -649,6 +653,10 @@ entries: map[hash,embed] = {}
                 }
             )
         });
+        assert_eq!(
+            err.diagnostic.to_string(),
+            "Type mismatch - expected hash, got bool"
+        );
     }
 
     #[test]
@@ -667,7 +675,7 @@ entries: map[hash,embed] = {}
     /// Quoted property names are hashed as written - `""` becomes `hash("")`.
     #[test]
     fn a_quoted_property_name_is_reported() {
-        assert_one_err(r#""": u32 = 1"#, |d| {
+        let err = assert_one_err(r#""": u32 = 1"#, |d| {
             matches!(
                 d,
                 Diagnostic::QuotedPropertyName {
@@ -679,6 +687,11 @@ entries: map[hash,embed] = {}
                 }
             )
         });
+        assert_eq!(
+            err.diagnostic.to_string(),
+            "Quoted property name - embed bodies take 'name: type = value', with the name \
+             unquoted or a '0x..' hash"
+        );
     }
 
     #[test]
@@ -763,33 +776,6 @@ entries: map[hash,embed] = {}
                 )
                 .build()
         );
-    }
-
-    /// `Display` is what the user reads, so check the ones this change added render as
-    /// sentences rather than as their `Debug` shape.
-    #[test]
-    fn new_diagnostics_render_a_message() {
-        let cases = [
-            (
-                "paramValues: list[embed] = { { name: string = \"A\" } }",
-                "Missing class name - embed values are written 'ClassName { .. }'",
-            ),
-            (
-                "name: string = \"A\"\n\"\"",
-                "embed takes an entry ('name: type = value')",
-            ),
-            (
-                "\"\": u32 = 1",
-                "Quoted property name - embed bodies take 'name: type = value', with the name \
-                 unquoted or a '0x..' hash",
-            ),
-            ("true: u32 = 3", "Type mismatch - expected hash, got bool"),
-        ];
-        for (input, expected) in cases {
-            let errs = build_errs(input);
-            assert_eq!(errs.len(), 1, "{input}: {errs:#?}");
-            assert_eq!(errs[0].diagnostic.to_string(), expected, "{input}");
-        }
     }
 
     /// The root `entries` map is the one every file has - its keys are quoted paths.

--- a/crates/ltk_ritobin/src/typecheck.rs
+++ b/crates/ltk_ritobin/src/typecheck.rs
@@ -20,14 +20,15 @@ pub use state::TypeChecker;
 #[cfg(test)]
 mod test {
     use glam::{Vec3, Vec4};
+    use ltk_hash::BinHash;
     use ltk_meta::{
         property::{values, NoMeta},
-        Bin, BinObject, ObjectBuilder, PropertyKind,
+        Bin, BinObject, ObjectBuilder, PropertyKind, PropertyValueEnum,
     };
 
     use crate::{
-        typecheck::diagnostics::{Diagnostic, DiagnosticWithSpan, RootKind},
-        Cst,
+        typecheck::diagnostics::{Diagnostic, DiagnosticWithSpan, ItemShape, RootKind},
+        Cst, RitoType,
     };
 
     fn wrap(input: &str) -> String {
@@ -332,5 +333,348 @@ entries: map[hash,embed] = {}
             "{:#?}",
             errs[0]
         );
+    }
+
+    /// Asserts `input` produces exactly one diagnostic, and hands it to `is`.
+    fn assert_one_err<F: Fn(&Diagnostic) -> bool>(input: &str, is: F) -> DiagnosticWithSpan {
+        let errs = build_errs(input);
+        assert_eq!(errs.len(), 1, "{errs:#?}");
+        assert!((is)(&errs[0].diagnostic), "{:#?}", errs[0]);
+        errs[0]
+    }
+
+    /// `pointer`/`embed` values are written `ClassName { .. }`. Deleting the class name
+    /// used to default-construct a class-hash-0 struct without a word.
+    #[test]
+    fn missing_class_name_in_a_list_item_is_reported() {
+        let err = assert_one_err(
+            r#"
+        paramValues: list[embed] = {
+            StaticMaterialShaderParamDef {
+                name: string = "A"
+            }
+            {
+                name: string = "B"
+            }
+        }
+        "#,
+            |d| {
+                matches!(
+                    d,
+                    Diagnostic::MissingClassName {
+                        expected: RitoType {
+                            base: PropertyKind::Embedded,
+                            ..
+                        },
+                        ..
+                    }
+                )
+            },
+        );
+        // points at the `{` the class name should precede, not the whole block
+        assert_eq!(err.span.len(), 1);
+    }
+
+    #[test]
+    fn missing_class_name_in_a_map_entry_is_reported() {
+        assert_one_err(
+            r#"
+        items: map[hash,pointer] = {
+            0xc8fd50ab = {
+                name: string = "a"
+            }
+        }
+        "#,
+            |d| {
+                matches!(
+                    d,
+                    Diagnostic::MissingClassName {
+                        expected: RitoType {
+                            base: PropertyKind::Struct,
+                            ..
+                        },
+                        ..
+                    }
+                )
+            },
+        );
+    }
+
+    /// A block list item is how nested containers are written - that must stay quiet.
+    #[test]
+    fn a_block_list_item_in_a_nested_container_is_fine() {
+        let errs = build_errs(r#"0x1: list[list[u32]] = { { 1 2 } { 3 4 } }"#);
+        assert!(errs.is_empty(), "{errs:#?}");
+    }
+
+    /// So must one that is properly introduced by a class name.
+    #[test]
+    fn a_named_class_list_item_is_fine() {
+        let errs = build_errs(
+            r#"
+        paramValues: list[embed] = {
+            StaticMaterialShaderParamDef {
+                name: string = "A"
+            }
+            0xdeadbeef {
+                name: string = "B"
+            }
+        }
+        "#,
+        );
+        assert!(errs.is_empty(), "{errs:#?}");
+    }
+
+    /// The reported case: `""` where a property name belongs. `merge_ir` used to drop any
+    /// child whose shape didn't fit, with a `trace!` and no diagnostic.
+    #[test]
+    fn a_bare_value_in_a_class_body_is_reported() {
+        assert_one_err(
+            r#"
+        name: string = "A"
+        ""
+        flags: u32 = 1
+        "#,
+            |d| {
+                matches!(
+                    d,
+                    Diagnostic::UnexpectedItem {
+                        expected: ItemShape::Entry,
+                        parent: RitoType {
+                            base: PropertyKind::Embedded,
+                            ..
+                        },
+                        ..
+                    }
+                )
+            },
+        );
+    }
+
+    #[test]
+    fn an_entry_in_a_list_is_reported() {
+        assert_one_err(r#"0x1: list[u32] = { key: u32 = 1 }"#, |d| {
+            matches!(
+                d,
+                Diagnostic::UnexpectedItem {
+                    expected: ItemShape::Value,
+                    parent: RitoType {
+                        base: PropertyKind::Container,
+                        ..
+                    },
+                    ..
+                }
+            )
+        });
+    }
+
+    #[test]
+    fn a_bare_value_in_a_map_is_reported() {
+        assert_one_err(r#"0x1: map[hash,u32] = { 5 }"#, |d| {
+            matches!(
+                d,
+                Diagnostic::UnexpectedItem {
+                    expected: ItemShape::Entry,
+                    parent: RitoType {
+                        base: PropertyKind::Map,
+                        ..
+                    },
+                    ..
+                }
+            )
+        });
+    }
+
+    #[test]
+    fn an_entry_in_an_option_is_reported() {
+        assert_one_err(r#"0x1: option[u32] = { key: u32 = 1 }"#, |d| {
+            matches!(
+                d,
+                Diagnostic::UnexpectedItem {
+                    expected: ItemShape::Value,
+                    parent: RitoType {
+                        base: PropertyKind::Optional,
+                        ..
+                    },
+                    ..
+                }
+            )
+        });
+    }
+
+    /// A key that can't become a hash was dropped silently by `merge_ir`.
+    #[test]
+    fn a_property_name_that_cannot_be_hashed_is_reported() {
+        assert_one_err(r#"true: u32 = 3"#, |d| {
+            matches!(
+                d,
+                Diagnostic::TypeMismatch {
+                    expected: RitoType {
+                        base: PropertyKind::Hash,
+                        ..
+                    },
+                    ..
+                }
+            )
+        });
+    }
+
+    #[test]
+    fn a_quoted_property_name_produces_the_same_property_as_a_bare_one() {
+        let quoted = wrap(r#""skinClassification": u32 = 1"#);
+        let bare = wrap(r#"skinClassification: u32 = 1"#);
+
+        let (quoted_bin, quoted_errs) = Cst::parse(&quoted).build_bin(&quoted);
+        let (bare_bin, bare_errs) = Cst::parse(&bare).build_bin(&bare);
+
+        assert_eq!(quoted_errs.len(), 1, "{quoted_errs:#?}");
+        assert!(bare_errs.is_empty(), "{bare_errs:#?}");
+        pretty_assertions::assert_eq!(quoted_bin, bare_bin);
+    }
+
+    /// Quoted property names are hashed as written - `""` becomes `hash("")`.
+    #[test]
+    fn a_quoted_property_name_is_reported() {
+        assert_one_err(r#""": u32 = 1"#, |d| {
+            matches!(
+                d,
+                Diagnostic::QuotedPropertyName {
+                    parent: RitoType {
+                        base: PropertyKind::Embedded,
+                        ..
+                    },
+                    ..
+                }
+            )
+        });
+    }
+
+    #[test]
+    fn map_keys_of_every_key_type_keep_their_pair() {
+        for (ty, key) in [
+            ("hash", r#"0x1"#),
+            ("hash", r#""Characters/Aatrox/Skins/Skin0""#),
+            ("string", r#""Characters/Aatrox/Skins/Skin0""#),
+            ("link", r#""Characters/Aatrox/Skins/Skin0""#),
+            ("file", r#""ASSETS/Maps/Textures/Bloom.tex""#),
+            ("file", r#"0x1"#),
+            ("u8", "1"),
+            ("u16", "1"),
+            ("u32", "1"),
+            ("u64", "1"),
+            ("i8", "-1"),
+            ("i16", "-1"),
+            ("i32", "-1"),
+            ("i64", "-1"),
+            ("f32", "1.5"),
+        ] {
+            let input = wrap(&format!("0x1: map[{ty},u32] = {{ {key} = 1 }}"));
+            let (bin, errs) = Cst::parse(&input).build_bin(&input);
+            assert!(errs.is_empty(), "map[{ty},u32] with key {key}: {errs:#?}");
+
+            // No diagnostics is not the same as no data lost - that is the whole failure
+            // mode this change is about, so check the pair actually reached the bin.
+            let PropertyValueEnum::Map(map) =
+                &bin.objects[&BinHash(0xDEADBEEF)].properties[&BinHash(1)]
+            else {
+                panic!("map[{ty},u32] with key {key}: property is not a map");
+            };
+            assert_eq!(
+                map.entries().len(),
+                1,
+                "map[{ty},u32] with key {key}: pair was dropped"
+            );
+        }
+    }
+
+    /// Numeric map keys are written and read bare. Upstream's `read_word` accepts only
+    /// `[A-Za-z0-9_+-.]`, so on `"7"` it stops at the quote and hands `read_number` an empty
+    /// word, which fails - see
+    /// <https://github.com/moonshadow565/ritobin/blob/d4b8764939d141c1db3ffd186d49bf60fd889b87/ritobin_lib/src/ritobin/bin_io_text_read.cpp#L69-L81>.
+    ///
+    /// The syntax is rejected rather than parsed out of the quotes, so a key whose contents
+    /// would have been a perfectly good number (`"7"`) is reported just the same as one that
+    /// could never be (`"abc"`).
+    #[test]
+    fn a_quoted_numeric_map_key_is_reported() {
+        for ty in ["u8", "u16", "u32", "u64", "i8", "i16", "i32", "i64", "f32"] {
+            for key in ["7", "0.5", "abc", ""] {
+                let errs = build_errs(&format!(r#"0x1: map[{ty},u32] = {{ "{key}" = 1 }}"#));
+                assert_eq!(errs.len(), 1, "map[{ty},u32] key {key:?}: {errs:#?}");
+                assert_eq!(
+                    errs[0].diagnostic.to_string(),
+                    format!("Type mismatch - expected {ty}, got string"),
+                    "map[{ty},u32] key {key:?}"
+                );
+            }
+        }
+    }
+
+    /// Reporting a rejected key does not recover the pair - it is still missing from the
+    /// bin. The diagnostic is the whole of the fix here.
+    #[test]
+    fn a_rejected_map_key_still_drops_the_pair() {
+        let input = wrap(r#"0x1: map[u32,u32] = { "0.5" = 1 }"#);
+        let (bin, errs) = Cst::parse(&input).build_bin(&input);
+
+        assert_eq!(errs.len(), 1, "{errs:#?}");
+        pretty_assertions::assert_eq!(
+            bin,
+            Bin::builder()
+                .object(
+                    BinObject::<NoMeta>::builder(0xDEADBEEF, 0x1234123)
+                        .property(
+                            0x1,
+                            values::Map::new(PropertyKind::U32, PropertyKind::U32, vec![]).unwrap()
+                        )
+                        .build()
+                )
+                .build()
+        );
+    }
+
+    /// `Display` is what the user reads, so check the ones this change added render as
+    /// sentences rather than as their `Debug` shape.
+    #[test]
+    fn new_diagnostics_render_a_message() {
+        let cases = [
+            (
+                "paramValues: list[embed] = { { name: string = \"A\" } }",
+                "Missing class name - embed values are written 'ClassName { .. }'",
+            ),
+            (
+                "name: string = \"A\"\n\"\"",
+                "embed takes an entry ('name: type = value')",
+            ),
+            (
+                "\"\": u32 = 1",
+                "Quoted property name - embed bodies take 'name: type = value', with the name \
+                 unquoted or a '0x..' hash",
+            ),
+            ("true: u32 = 3", "Type mismatch - expected hash, got bool"),
+        ];
+        for (input, expected) in cases {
+            let errs = build_errs(input);
+            assert_eq!(errs.len(), 1, "{input}: {errs:#?}");
+            assert_eq!(errs[0].diagnostic.to_string(), expected, "{input}");
+        }
+    }
+
+    /// The root `entries` map is the one every file has - its keys are quoted paths.
+    #[test]
+    fn a_quoted_root_entry_key_is_fine() {
+        let input = r#"
+type: string = "PROP"
+version: u32 = 3
+linked: list[string] = {}
+entries: map[hash,embed] = {
+    "Characters/Aatrox/Skins/Skin0" = 0x1234123 {
+        0x1: u32 = 1
+    }
+}
+"#;
+        let cst = Cst::parse(input);
+        let (_, errs) = cst.build_bin(input);
+        assert!(errs.is_empty(), "{errs:#?}");
     }
 }

--- a/crates/ltk_ritobin/src/typecheck/diagnostics.rs
+++ b/crates/ltk_ritobin/src/typecheck/diagnostics.rs
@@ -1,4 +1,4 @@
-use std::fmt::Display;
+use std::{fmt::Display, num::IntErrorKind};
 
 use ltk_meta::PropertyKind;
 
@@ -8,12 +8,31 @@ use crate::{
     RitoType,
 };
 
+/// One of the four entries every ritobin file has at its root.
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
 pub enum RootKind {
     Type,
     Version,
     Linked,
     Entries,
+}
+
+impl RootKind {
+    /// The name this root entry is written with in a ritobin file.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            RootKind::Type => "type",
+            RootKind::Version => "version",
+            RootKind::Linked => "linked",
+            RootKind::Entries => "entries",
+        }
+    }
+}
+
+impl Display for RootKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -46,6 +65,27 @@ impl Display for RitoTypeOrVirtual {
             Self::Token(kind) => Display::fmt(kind, f),
             Self::Tree(kind) => Display::fmt(kind, f),
         }
+    }
+}
+
+/// The shape an item must have to be accepted by its parent.
+///
+/// Which one a parent wants is a property of the parent's type: class bodies and maps take
+/// [`Entry`](ItemShape::Entry)s, lists and options take [`Value`](ItemShape::Value)s.
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub enum ItemShape {
+    /// `key: type = value` (or `key = value`)
+    Entry,
+    /// a bare value
+    Value,
+}
+
+impl Display for ItemShape {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            ItemShape::Entry => "an entry ('name: type = value')",
+            ItemShape::Value => "a value",
+        })
     }
 }
 
@@ -83,7 +123,11 @@ impl Display for ListLike {
     }
 }
 
+/// Something the type checker found wrong with a tree.
+///
+/// Each variant carries the spans needed to point at the offending source. Use [`Display`] to render the user-facing message.
 #[derive(Debug, Clone, Copy)]
+#[non_exhaustive]
 pub enum Diagnostic {
     CustomSpan(&'static str, Span),
 
@@ -122,6 +166,38 @@ pub enum Diagnostic {
         span: Span,
         expected: RitoType,
         expected_span: Option<Span>,
+    },
+
+    /// A value needing a class name was written as a bare block.
+    ///
+    /// `pointer` and `embed` values are `ClassName { .. }`; without the name there is
+    /// nothing to resolve the class from, and the value defaults to class hash 0.
+    MissingClassName {
+        /// span of the `{` the class name should have preceded
+        span: Span,
+        /// the type that requires the class name
+        expected: RitoType,
+    },
+
+    /// An item has the wrong shape for its parent.
+    ///
+    /// A bare value in a class body, an entry in a list, and so on. The item cannot be
+    /// merged into the parent, so it is missing from the bin.
+    UnexpectedItem {
+        /// span of the offending item
+        span: Span,
+        /// the parent that rejected it
+        parent: RitoType,
+        /// the shape `parent` needs
+        expected: ItemShape,
+    },
+
+    /// A property name was written with quotes.
+    QuotedPropertyName {
+        /// span of the quoted key, quotes included
+        span: Span,
+        /// the parent class
+        parent: RitoType,
     },
 
     ResolveLiteral,
@@ -169,6 +245,109 @@ pub enum Diagnostic {
     },
 }
 
+impl Display for Diagnostic {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use Diagnostic::*;
+        match self {
+            CustomSpan(msg, _) => f.write_str(msg),
+
+            UnexpectedTree {
+                tree,
+                expected: Some(expected),
+                ..
+            } => write!(f, "Unexpected {tree}, expected {expected}"),
+            UnexpectedTree {
+                tree,
+                expected: None,
+                ..
+            } => write!(f, "Unexpected {tree}"),
+            MissingTree(kind) => write!(f, "Missing {kind}"),
+            EmptyTree(kind) => write!(f, "Empty {kind}"),
+            MissingToken(kind) => write!(f, "Missing {kind}"),
+
+            UnknownType(_) => f.write_str("Unknown type"),
+            MissingType(_) => {
+                f.write_str("Missing type - entries are written 'name: type = value'")
+            }
+
+            MissingRootEntry { root_kind } => write!(f, "Missing root entry '{root_kind}'"),
+            InvalidRootEntryType {
+                root_kind,
+                got,
+                expected,
+                ..
+            } => write!(f, "Root entry '{root_kind}' must be {expected}, got {got}"),
+
+            TypeMismatch { expected, got, .. } => {
+                write!(f, "Type mismatch - expected {expected}, got {got}")
+            }
+            UnexpectedContainerItem { expected, .. } => write!(
+                f,
+                "{expected} does not accept container items / blocks - remove the curly \
+                 braces around the value"
+            ),
+            MissingClassName { expected, .. } => write!(
+                f,
+                "Missing class name - {expected} values are written 'ClassName {{ .. }}'"
+            ),
+            UnexpectedItem {
+                parent, expected, ..
+            } => write!(f, "{parent} takes {expected}"),
+            QuotedPropertyName { parent, .. } => write!(
+                f,
+                "Quoted property name - {parent} bodies take 'name: type = value', with the \
+                 name unquoted or a '0x..' hash"
+            ),
+
+            ResolveLiteral => f.write_str("Could not resolve literal"),
+            ParseNumericError {
+                expected, error, ..
+            } => {
+                let reason = match error {
+                    Some(IntErrorKind::Empty) => "cannot parse integer from empty literal",
+                    Some(IntErrorKind::InvalidDigit) => "invalid digit found in literal",
+                    Some(IntErrorKind::PosOverflow) => "number too large to fit in target type",
+                    Some(IntErrorKind::NegOverflow) => "number too small to fit in target type",
+                    Some(IntErrorKind::Zero) => "number would be zero",
+                    _ => "invalid literal",
+                };
+                write!(
+                    f,
+                    "Could not parse {} - {reason}",
+                    RitoType::simple(*expected)
+                )
+            }
+            AmbiguousNumeric(_) => {
+                f.write_str("Ambiguous numeric literal - it needs a type to be resolved against")
+            }
+
+            NotEnoughItems { got, expected, .. } => write!(
+                f,
+                "{expected} needs {} items - got {got}",
+                expected.needed_children()
+            ),
+            TooManyItems {
+                extra, expected, ..
+            } => write!(
+                f,
+                "{expected} needs {} items - got {extra} too many",
+                expected.needed_children()
+            ),
+
+            RootNonEntry => f.write_str("Top-level bin entries are written 'name: type = value'"),
+            UnknownRoot { .. } => f.write_str("Unknown root entry"),
+            ShadowedEntry { .. } => f.write_str("Entry shadows a previous entry with the same key"),
+
+            InvalidHash(_) => f.write_str("Invalid hash"),
+
+            SubtypeCountMismatch { got, expected, .. } => {
+                write!(f, "Expected {expected} type parameters, got {got}")
+            }
+            UnexpectedSubtypes { .. } => f.write_str("This type does not accept type parameters"),
+        }
+    }
+}
+
 impl Diagnostic {
     pub fn span(&self) -> Option<&Span> {
         use Diagnostic::*;
@@ -186,6 +365,9 @@ impl Diagnostic {
             | SubtypeCountMismatch { span, .. }
             | UnexpectedSubtypes { span, .. }
             | UnexpectedContainerItem { span, .. }
+            | MissingClassName { span, .. }
+            | UnexpectedItem { span, .. }
+            | QuotedPropertyName { span, .. }
             | MissingType(span)
             | TypeMismatch { span, .. }
             | ShadowedEntry { shadower: span, .. }

--- a/crates/ltk_ritobin/src/typecheck/diagnostics.rs
+++ b/crates/ltk_ritobin/src/typecheck/diagnostics.rs
@@ -5,7 +5,7 @@ use ltk_meta::PropertyKind;
 use crate::{
     cst,
     parse::{Span, TokenKind},
-    RitoType,
+    ItemShape, RitoType,
 };
 
 /// One of the four entries every ritobin file has at its root.
@@ -65,27 +65,6 @@ impl Display for RitoTypeOrVirtual {
             Self::Token(kind) => Display::fmt(kind, f),
             Self::Tree(kind) => Display::fmt(kind, f),
         }
-    }
-}
-
-/// The shape an item must have to be accepted by its parent.
-///
-/// Which one a parent wants is a property of the parent's type: class bodies and maps take
-/// [`Entry`](ItemShape::Entry)s, lists and options take [`Value`](ItemShape::Value)s.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
-pub enum ItemShape {
-    /// `key: type = value` (or `key = value`)
-    Entry,
-    /// a bare value
-    Value,
-}
-
-impl Display for ItemShape {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(match self {
-            ItemShape::Entry => "an entry ('name: type = value')",
-            ItemShape::Value => "a value",
-        })
     }
 }
 

--- a/crates/ltk_ritobin/src/typecheck/ir.rs
+++ b/crates/ltk_ritobin/src/typecheck/ir.rs
@@ -6,6 +6,8 @@ use crate::parse::Span;
 pub struct IrEntry {
     pub key: PropertyValueEnum<Span>,
     pub value: PropertyValueEnum<Span>,
+    /// Span of the type expression this entry's value type came from, if any.
+    pub type_span: Option<Span>,
 }
 
 #[derive(Debug, Clone)]
@@ -50,11 +52,29 @@ impl IrItem {
         }
     }
 
-    /// Span to the source of the item's shape.
-    pub fn shape_span(&self) -> Span {
+    /// Span of the whole item, an entry's key through its value.
+    ///
+    /// An [`IrListItem`] has no key, so there it is just the value. A parent that rejects an item
+    /// rejects all of it, so this is what a diagnostic about the item underlines.
+    pub fn span(&self) -> Span {
         match self {
-            IrItem::Entry(IrEntry { key, .. }) => *key.meta(),
+            IrItem::Entry(IrEntry { key, value, .. }) => {
+                let (key, value) = (*key.meta(), *value.meta());
+                // a recovered tree can hand us a value that starts before its own key
+                Span::new(key.start, value.end.max(key.end))
+            }
             IrItem::ListItem(IrListItem(value)) => *value.meta(),
+        }
+    }
+
+    /// Span of the type expression this item's type came from, if any.
+    ///
+    /// An [`IrListItem`] takes its type from its parent's subtype rather than declaring one, so it
+    /// never has a type expression of its own to point at.
+    pub fn type_span(&self) -> Option<Span> {
+        match self {
+            IrItem::Entry(entry) => entry.type_span,
+            IrItem::ListItem(_) => None,
         }
     }
 

--- a/crates/ltk_ritobin/src/typecheck/ir.rs
+++ b/crates/ltk_ritobin/src/typecheck/ir.rs
@@ -1,4 +1,4 @@
-use ltk_meta::PropertyValueEnum;
+use ltk_meta::{traits::PropertyExt as _, PropertyValueEnum};
 
 use crate::parse::Span;
 
@@ -49,6 +49,15 @@ impl IrItem {
             IrItem::ListItem(i) => &mut i.0,
         }
     }
+
+    /// Span to the source of the item's shape.
+    pub fn shape_span(&self) -> Span {
+        match self {
+            IrItem::Entry(IrEntry { key, .. }) => *key.meta(),
+            IrItem::ListItem(IrListItem(value)) => *value.meta(),
+        }
+    }
+
     pub fn into_value(self) -> PropertyValueEnum<Span> {
         match self {
             IrItem::Entry(i) => i.value,

--- a/crates/ltk_ritobin/src/typecheck/listlikes.rs
+++ b/crates/ltk_ritobin/src/typecheck/listlikes.rs
@@ -11,26 +11,32 @@ use crate::{
 
 use diagnostics::Diagnostic::*;
 
-fn resolve_f32(n: PropertyValueEnum<Span>) -> Result<f32, MaybeSpanDiag> {
+fn resolve_f32(
+    n: PropertyValueEnum<Span>,
+    expected_span: Option<Span>,
+) -> Result<f32, MaybeSpanDiag> {
     match n {
         PropertyValueEnum::F32(values::F32 { value: n, .. }) => Ok(n),
         _ => Err(TypeMismatch {
             span: *n.meta(),
             expected: RitoType::simple(PropertyKind::F32),
-            expected_span: None, // TODO: would be nice
+            expected_span,
             got: RitoTypeOrVirtual::RitoType(RitoType::simple(n.kind())),
         }
         .into()),
     }
 }
 
-fn resolve_u8(n: PropertyValueEnum<Span>) -> Result<u8, MaybeSpanDiag> {
+fn resolve_u8(
+    n: PropertyValueEnum<Span>,
+    expected_span: Option<Span>,
+) -> Result<u8, MaybeSpanDiag> {
     match n {
         PropertyValueEnum::U8(values::U8 { value: n, .. }) => Ok(n),
         _ => Err(TypeMismatch {
             span: *n.meta(),
             expected: RitoType::simple(PropertyKind::U8),
-            expected_span: None, // TODO: would be nice
+            expected_span,
             got: RitoTypeOrVirtual::RitoType(RitoType::simple(n.kind())),
         }
         .into()),
@@ -40,14 +46,17 @@ fn resolve_u8(n: PropertyValueEnum<Span>) -> Result<u8, MaybeSpanDiag> {
 struct ListIter<I: Iterator<Item = IrListItem>> {
     items: I,
     span: Span,
+    /// span of the type expression that made this a listlike, to blame component types on
+    type_span: Option<Span>,
     count: u8,
 }
 
 impl<I: Iterator<Item = IrListItem>> ListIter<I> {
-    fn new(span: Span, items: I) -> Self {
+    fn new(span: Span, type_span: Option<Span>, items: I) -> Self {
         Self {
             items,
             span,
+            type_span,
             count: 0,
         }
     }
@@ -82,14 +91,14 @@ impl<I: Iterator<Item = IrListItem>> ListIter<I> {
     ) -> Result<[f32; N], MaybeSpanDiag> {
         let mut out = [0.0f32; N];
         for slot in &mut out {
-            *slot = resolve_f32(self.expect_next(expected)?)?;
+            *slot = resolve_f32(self.expect_next(expected)?, self.type_span)?;
         }
         Ok(out)
     }
     fn read_u8s<const N: usize>(&mut self, expected: ListLike) -> Result<[u8; N], MaybeSpanDiag> {
         let mut out = [0u8; N];
         for slot in &mut out {
-            *slot = resolve_u8(self.expect_next(expected)?)?;
+            *slot = resolve_u8(self.expect_next(expected)?, self.type_span)?;
         }
         Ok(out)
     }
@@ -155,10 +164,26 @@ impl<I: Iterator<Item = IrListItem>> ListIter<I> {
     }
 }
 
-/// Try populate a listlike type (vec, mtx44, rgba, option[listlike])
+/// Fills a listlike (vec, mtx44, rgba, option[listlike]) from the items collected for it.
+///
+/// A listlike spells its components out as bare values, so they arrive as ordinary list items and
+/// have to be folded back into one value once the block closes.
+///
+/// - `target` - the value to fill; left alone when it turns out not to be a listlike
+/// - `items` - the queued list items, drained into `target`
+/// - `type_span` - where `target`'s type was written, so a component of the wrong type can point
+///   at the `vec3`/`rgba`/... that decided what its components had to be
+///
+/// # Returns
+/// `Ok(())` when `target` is not a listlike, so callers can hand every value to it.
+///
+/// # Errors
+/// If `target` is a listlike and `items` does not fill it - too few components, too many, or one
+/// that is not the `f32`/`u8` the shape needs.
 pub(crate) fn try_populate_listlike(
     target: &mut IrItem,
     items: &mut Vec<IrListItem>,
+    type_span: Option<Span>,
 ) -> Result<(), MaybeSpanDiag> {
     use PropertyValueEnum as V;
 
@@ -168,7 +193,7 @@ pub(crate) fn try_populate_listlike(
     }
 
     // TODO: is this the right span to start with?
-    let mut items = ListIter::new(*target.value().meta(), items.drain(..));
+    let mut items = ListIter::new(*target.value().meta(), type_span, items.drain(..));
 
     let mut inject =
         |target: &mut PropertyValueEnum<Span>| -> Result<Option<ListLike>, MaybeSpanDiag> {

--- a/crates/ltk_ritobin/src/typecheck/resolve.rs
+++ b/crates/ltk_ritobin/src/typecheck/resolve.rs
@@ -360,6 +360,26 @@ pub(crate) fn resolve_value(
                 }
             }
         }
+
+        // Matches a block with no class name - { .. }
+        Some(
+            block @ Node {
+                kind: Kind::Block, ..
+            },
+        ) => {
+            let Some(kind_hint) = kind_hint else {
+                return Ok(None);
+            };
+            if !matches!(kind_hint.base, K::Struct | K::Embedded) {
+                return Ok(None);
+            }
+
+            // Structs and embedded values must have a class name before the block
+            return Err(MissingClassName {
+                span: block.open_brace_span(visit_ctx.cst),
+                expected: kind_hint,
+            });
+        }
         Some(Node {
             kind: Kind::Literal,
             children,
@@ -398,10 +418,27 @@ pub(crate) fn resolve_entry(
         Some(Token {
             kind: TokenKind::String,
             span,
-        }) => PropertyValueEnum::from(values::String::new_with_meta(
-            ctx.text[Span::new(span.start + 1, span.end - 1)].into(),
-            *span,
-        )),
+        }) => {
+            // We can support quoted property names by just hashing the string
+            // The original ritobin compiler has no support for it and we prefer
+            // unquoted names - emit diagnostic
+            if let Some(parent) = parent_value_kind
+                .filter(|p| matches!(p.base, PropertyKind::Struct | PropertyKind::Embedded))
+            {
+                ctx.diagnostics.push(
+                    QuotedPropertyName {
+                        span: *span,
+                        parent,
+                    }
+                    .unwrap(),
+                );
+            }
+
+            PropertyValueEnum::from(values::String::new_with_meta(
+                ctx.text[Span::new(span.start + 1, span.end - 1)].into(),
+                *span,
+            ))
+        }
         Some(Token {
             kind: TokenKind::HexLit,
             span,

--- a/crates/ltk_ritobin/src/typecheck/resolve.rs
+++ b/crates/ltk_ritobin/src/typecheck/resolve.rs
@@ -189,10 +189,22 @@ fn parse_int<T: std::str::FromStr<Err = std::num::ParseIntError>>(
         })
 }
 
+/// Resolves a single literal token into the value it spells.
+///
+/// - `ctx` - typecheck state; diagnostics found along the way are pushed here
+/// - `token` - the literal to resolve
+/// - `kind_hint` - the type to read the literal as. A number, `true` or a string can be several
+///   types, so without a hint an ambiguous literal cannot be resolved at all
+/// - `kind_hint_span` - where `kind_hint` was written, so a mismatch can point at it
+///
+/// # Errors
+/// If the literal does not fit `kind_hint`, or if it is ambiguous and there is no hint to pick
+/// with - a bare `5` on its own has no type.
 fn resolve_literal(
     ctx: &mut Ctx,
     token: &Token,
     kind_hint: Option<RitoType>,
+    kind_hint_span: Option<Span>,
 ) -> Result<Option<PropertyValueEnum<Span>>, Diagnostic> {
     use PropertyKind as K;
     use PropertyValueEnum as P;
@@ -275,7 +287,7 @@ fn resolve_literal(
                     return Err(TypeMismatch {
                         span: *span,
                         expected: RitoType::simple(kind_hint),
-                        expected_span: None, // TODO: would be nice here
+                        expected_span: kind_hint_span,
                         got: RitoTypeOrVirtual::numeric(),
                     });
                 }
@@ -285,11 +297,28 @@ fn resolve_literal(
     }))
 }
 
+/// Resolves an `EntryValue` or `ListItem` tree into the value it describes.
+///
+/// - `ctx` - typecheck state; diagnostics found along the way are pushed here
+/// - `visit_ctx` - the CST being walked
+/// - `tree` - the tree holding the value
+/// - `kind_hint` - the type the value is expected to have, used to resolve literals that cannot
+///   type themselves - a bare `5` is only a `u8` because something said so
+/// - `kind_hint_span` - where `kind_hint` was written, so a mismatch can point at it
+///
+/// # Returns
+/// `Ok(None)` when the tree holds nothing resolvable, which the caller reports in its own terms -
+/// an empty list item is a different mistake from an empty entry.
+///
+/// # Errors
+/// If the value cannot be read as `kind_hint` - a literal of the wrong type, a number that does
+/// not fit, or an ambiguous literal with no hint to resolve it against.
 pub(crate) fn resolve_value(
     ctx: &mut Ctx,
     visit_ctx: &VisitCtx,
     tree: &Node,
     kind_hint: Option<RitoType>,
+    kind_hint_span: Option<Span>,
 ) -> Result<Option<PropertyValueEnum<Span>>, Diagnostic> {
     use PropertyKind as K;
     use PropertyValueEnum as P;
@@ -388,17 +417,37 @@ pub(crate) fn resolve_value(
             let Some(child) = children.get(visit_ctx.cst).first() else {
                 return Ok(None);
             };
-            return resolve_literal(ctx, child.token(visit_ctx.cst).unwrap(), kind_hint);
+            return resolve_literal(
+                ctx,
+                child.token(visit_ctx.cst).unwrap(),
+                kind_hint,
+                kind_hint_span,
+            );
         }
         _ => return Ok(None),
     }))
 }
 
+/// Resolves an `Entry` tree into the key/value pair it describes.
+///
+/// - `ctx` - typecheck state; diagnostics found along the way are pushed here
+/// - `visit_ctx` - the CST being walked
+/// - `tree` - the `Entry` tree to resolve
+/// - `parent_value_kind` - the type the enclosing container gives its values, so an entry that
+///   wrote no `: type` can still be resolved. `None` at the root
+/// - `parent_type_span` - where that type was written, so a mismatch can point at it. `None` at
+///   the root, and for a container that took its type from a subtype rather than a type expression
+///
+/// # Errors
+/// If the tree is not a well-formed entry - no key, no value, or a key that is not a hash.
+/// A well-formed entry that fails to type-check resolves to a default value instead, so the walk
+/// keeps going and the diagnostic lands in `ctx`.
 pub(crate) fn resolve_entry(
     ctx: &mut Ctx,
     visit_ctx: &VisitCtx,
     tree: &Node,
     parent_value_kind: Option<RitoType>,
+    parent_type_span: Option<Span>,
 ) -> Result<IrEntry, MaybeSpanDiag> {
     let mut c = tree.children.get(visit_ctx.cst).iter();
 
@@ -449,6 +498,7 @@ pub(crate) fn resolve_entry(
             parent_value_kind
                 .and_then(|k| k.subtypes[0])
                 .map(RitoType::simple),
+            parent_type_span,
         )?
         .ok_or(CustomSpan("erm idk bad literal", key.span))?,
         _ => {
@@ -482,13 +532,15 @@ pub(crate) fn resolve_entry(
                     TypeMismatch {
                         span: kind_span,
                         expected: *parent,
-                        expected_span: None, // TODO: would be nice here
+                        expected_span: parent_type_span,
                         got: (*kind).into(),
                     }
                     .unwrap(),
                 );
                 return Ok(IrEntry {
                     key,
+                    // we fell back to the parent's type, so that is what declared this value
+                    type_span: parent_type_span,
                     value: parent.make_default(value.span),
                 });
             }
@@ -496,8 +548,9 @@ pub(crate) fn resolve_entry(
     }
 
     let kind = kind.or(parent_value_kind);
+    let type_span = kind_span.or(parent_type_span);
 
-    let resolved_val = match resolve_value(ctx, visit_ctx, value, kind) {
+    let resolved_val = match resolve_value(ctx, visit_ctx, value, kind, type_span) {
         Ok(v) => v,
         Err(e) => Some(match kind {
             Some(kind) => {
@@ -534,5 +587,9 @@ pub(crate) fn resolve_entry(
         (Some(kind), _) => kind.make_default(value_span),
     };
 
-    Ok(IrEntry { key, value })
+    Ok(IrEntry {
+        key,
+        value,
+        type_span,
+    })
 }

--- a/crates/ltk_ritobin/src/typecheck/walk.rs
+++ b/crates/ltk_ritobin/src/typecheck/walk.rs
@@ -8,7 +8,7 @@ use crate::{
     },
     parse::Span,
     typecheck::{
-        diagnostics::{self, RitoTypeOrVirtual},
+        diagnostics::{self, ItemShape, RitoTypeOrVirtual},
         ir::{IrEntry, IrItem, IrListItem},
     },
     PropertyValueExt as _, RitoType,
@@ -44,7 +44,34 @@ impl<'a> TypeChecker<'a> {
         }
     }
 
+    /// Reports a child whose shape its parent does not accept.
+    fn report_wrong_item_shape(&mut self, child: &IrItem, parent: RitoType, expected: ItemShape) {
+        self.ctx.diagnostics.push(
+            UnexpectedItem {
+                span: child.shape_span(),
+                parent,
+                expected,
+            }
+            .unwrap(),
+        );
+    }
+
+    /// Reports an entry key that cannot become the key type its parent needs.
+    fn report_bad_entry_key(&mut self, span: Span, got: RitoType, expected: PropertyKind) {
+        self.ctx.diagnostics.push(
+            TypeMismatch {
+                span,
+                expected: RitoType::simple(expected),
+                expected_span: None, // TODO: would be nice here
+                got: got.into(),
+            }
+            .unwrap(),
+        );
+    }
+
     fn merge_ir(&mut self, mut parent: IrItem, child: IrItem) -> IrItem {
+        let parent_type = parent.value().rito_type();
+
         match &mut parent.value_mut() {
             PropertyValueEnum::Container(list)
             | PropertyValueEnum::UnorderedContainer(values::UnorderedContainer(list)) => {
@@ -58,42 +85,60 @@ impl<'a> TypeChecker<'a> {
                         let result = list.push(value);
                         self.handle_container_res(span, result);
                     }
-                    IrItem::Entry(IrEntry { key: _, value: _ }) => {
+                    child @ IrItem::Entry(_) => {
                         trace!("\x1b[41mlist item must be list item\x1b[0m");
+                        self.report_wrong_item_shape(&child, parent_type, ItemShape::Value);
                         return parent;
                     }
                 }
             }
             PropertyValueEnum::Struct(struct_val)
             | PropertyValueEnum::Embedded(values::Embedded(struct_val)) => {
-                let IrItem::Entry(IrEntry { key, value }) = child else {
-                    trace!("\x1b[41mstruct item must be entry\x1b[0m");
-                    return parent;
+                let IrEntry { key, value } = match child {
+                    IrItem::Entry(entry) => entry,
+                    child => {
+                        trace!("\x1b[41mstruct item must be entry\x1b[0m");
+                        self.report_wrong_item_shape(&child, parent_type, ItemShape::Entry);
+                        return parent;
+                    }
                 };
 
+                let (key_span, key_type) = (*key.meta(), key.rito_type());
                 let Some(PropertyValueEnum::Hash(key)) = coerce_type(key, PropertyKind::Hash)
                 else {
+                    self.report_bad_entry_key(key_span, key_type, PropertyKind::Hash);
                     return parent;
                 };
 
                 struct_val.properties.insert(*key, value);
             }
             PropertyValueEnum::Map(map_value) => {
-                let IrItem::Entry(IrEntry { key, value }) = child else {
-                    trace!("map item must be entry");
-                    return parent;
+                let IrEntry { key, value } = match child {
+                    IrItem::Entry(entry) => entry,
+                    child => {
+                        trace!("map item must be entry");
+                        self.report_wrong_item_shape(&child, parent_type, ItemShape::Entry);
+                        return parent;
+                    }
                 };
                 let span = *value.meta();
-                let Some(key) = coerce_type(key, map_value.key_kind()) else {
+                let key_kind = map_value.key_kind();
+                let (key_span, key_type) = (*key.meta(), key.rito_type());
+                let Some(key) = coerce_type(key, key_kind) else {
+                    self.report_bad_entry_key(key_span, key_type, key_kind);
                     return parent;
                 };
                 let result = map_value.push(key, value);
                 self.handle_container_res(span, result);
             }
             PropertyValueEnum::Optional(option) => {
-                let IrItem::ListItem(IrListItem(child)) = child else {
-                    trace!("\x1b[41moptional value must be list item\x1b[0m");
-                    return parent;
+                let IrListItem(child) = match child {
+                    IrItem::ListItem(item) => item,
+                    child => {
+                        trace!("\x1b[41moptional value must be list item\x1b[0m");
+                        self.report_wrong_item_shape(&child, parent_type, ItemShape::Value);
+                        return parent;
+                    }
                 };
                 if child.kind() != option.item_kind() {
                     self.ctx.diagnostics.push(
@@ -161,6 +206,16 @@ impl Visitor for TypeChecker<'_> {
                         let value_type = parent_type
                             .value_subtype()
                             .expect("container must have value_subtype");
+
+                        if matches!(value_type, K::Struct | K::Embedded) {
+                            self.ctx.diagnostics.push(
+                                MissingClassName {
+                                    span: tree.open_brace_span(ctx.cst),
+                                    expected: RitoType::simple(value_type),
+                                }
+                                .unwrap(),
+                            );
+                        }
 
                         self.stack.push((
                             depth,

--- a/crates/ltk_ritobin/src/typecheck/walk.rs
+++ b/crates/ltk_ritobin/src/typecheck/walk.rs
@@ -8,7 +8,7 @@ use crate::{
     },
     parse::Span,
     typecheck::{
-        diagnostics::{self, ItemShape, RitoTypeOrVirtual},
+        diagnostics::{self, RitoTypeOrVirtual},
         ir::{IrEntry, IrItem, IrListItem},
     },
     PropertyValueExt as _, RitoType,
@@ -24,7 +24,17 @@ use super::{
 use diagnostics::Diagnostic::*;
 
 impl<'a> TypeChecker<'a> {
-    fn handle_container_res(&mut self, span: Span, result: Result<(), ltk_meta::Error>) {
+    /// Reports whatever a container had to say about the value just pushed into it.
+    ///
+    /// - `span` - the value that was pushed, to underline
+    /// - `expected_span` - where the container's type was written, so a rejection can point at it
+    /// - `result` - what the push returned
+    fn handle_container_res(
+        &mut self,
+        span: Span,
+        expected_span: Option<Span>,
+        result: Result<(), ltk_meta::Error>,
+    ) {
         match result {
             Ok(()) => {}
             Err(ltk_meta::Error::MismatchedContainerTypes { expected, got }) => {
@@ -32,7 +42,7 @@ impl<'a> TypeChecker<'a> {
                     TypeMismatch {
                         span,
                         expected: RitoType::simple(expected),
-                        expected_span: None, // TODO: would be nice here
+                        expected_span,
                         got: RitoType::simple(got).into(),
                     }
                     .unwrap(),
@@ -45,10 +55,21 @@ impl<'a> TypeChecker<'a> {
     }
 
     /// Reports a child whose shape its parent does not accept.
-    fn report_wrong_item_shape(&mut self, child: &IrItem, parent: RitoType, expected: ItemShape) {
+    ///
+    /// - `child` - the offending item, underlined whole because that is what the parent rejected
+    /// - `parent` - the type that rejected it, which also fixes the shape it wanted
+    ///
+    /// # Panics
+    /// If `parent` has no body to hold items. Only the arms of [`Self::merge_ir`] that accept
+    /// children reach this - anything else lands in its catch-all as an `UnexpectedContainerItem`.
+    fn report_wrong_item_shape(&mut self, child: &IrItem, parent: RitoType) {
+        let expected = parent
+            .item_shape()
+            .expect("only a parent with a body can reject an item shape");
+
         self.ctx.diagnostics.push(
             UnexpectedItem {
-                span: child.shape_span(),
+                span: child.span(),
                 parent,
                 expected,
             }
@@ -57,12 +78,24 @@ impl<'a> TypeChecker<'a> {
     }
 
     /// Reports an entry key that cannot become the key type its parent needs.
-    fn report_bad_entry_key(&mut self, span: Span, got: RitoType, expected: PropertyKind) {
+    ///
+    /// - `span` - the key, to underline
+    /// - `got` - the type the key resolved to
+    /// - `expected` - the key type the parent needs
+    /// - `expected_span` - where that type was written, or `None` when nothing wrote it - a
+    ///   property name is a hash because it is a property name, not because of a type expression
+    fn report_bad_entry_key(
+        &mut self,
+        span: Span,
+        got: RitoType,
+        expected: PropertyKind,
+        expected_span: Option<Span>,
+    ) {
         self.ctx.diagnostics.push(
             TypeMismatch {
                 span,
                 expected: RitoType::simple(expected),
-                expected_span: None, // TODO: would be nice here
+                expected_span,
                 got: got.into(),
             }
             .unwrap(),
@@ -71,6 +104,7 @@ impl<'a> TypeChecker<'a> {
 
     fn merge_ir(&mut self, mut parent: IrItem, child: IrItem) -> IrItem {
         let parent_type = parent.value().rito_type();
+        let expected_span = parent.type_span();
 
         match &mut parent.value_mut() {
             PropertyValueEnum::Container(list)
@@ -83,22 +117,22 @@ impl<'a> TypeChecker<'a> {
 
                         let span = *value.meta();
                         let result = list.push(value);
-                        self.handle_container_res(span, result);
+                        self.handle_container_res(span, expected_span, result);
                     }
                     child @ IrItem::Entry(_) => {
                         trace!("\x1b[41mlist item must be list item\x1b[0m");
-                        self.report_wrong_item_shape(&child, parent_type, ItemShape::Value);
+                        self.report_wrong_item_shape(&child, parent_type);
                         return parent;
                     }
                 }
             }
             PropertyValueEnum::Struct(struct_val)
             | PropertyValueEnum::Embedded(values::Embedded(struct_val)) => {
-                let IrEntry { key, value } = match child {
+                let IrEntry { key, value, .. } = match child {
                     IrItem::Entry(entry) => entry,
                     child => {
                         trace!("\x1b[41mstruct item must be entry\x1b[0m");
-                        self.report_wrong_item_shape(&child, parent_type, ItemShape::Entry);
+                        self.report_wrong_item_shape(&child, parent_type);
                         return parent;
                     }
                 };
@@ -106,18 +140,18 @@ impl<'a> TypeChecker<'a> {
                 let (key_span, key_type) = (*key.meta(), key.rito_type());
                 let Some(PropertyValueEnum::Hash(key)) = coerce_type(key, PropertyKind::Hash)
                 else {
-                    self.report_bad_entry_key(key_span, key_type, PropertyKind::Hash);
+                    self.report_bad_entry_key(key_span, key_type, PropertyKind::Hash, None);
                     return parent;
                 };
 
                 struct_val.properties.insert(*key, value);
             }
             PropertyValueEnum::Map(map_value) => {
-                let IrEntry { key, value } = match child {
+                let IrEntry { key, value, .. } = match child {
                     IrItem::Entry(entry) => entry,
                     child => {
                         trace!("map item must be entry");
-                        self.report_wrong_item_shape(&child, parent_type, ItemShape::Entry);
+                        self.report_wrong_item_shape(&child, parent_type);
                         return parent;
                     }
                 };
@@ -125,18 +159,18 @@ impl<'a> TypeChecker<'a> {
                 let key_kind = map_value.key_kind();
                 let (key_span, key_type) = (*key.meta(), key.rito_type());
                 let Some(key) = coerce_type(key, key_kind) else {
-                    self.report_bad_entry_key(key_span, key_type, key_kind);
+                    self.report_bad_entry_key(key_span, key_type, key_kind, expected_span);
                     return parent;
                 };
                 let result = map_value.push(key, value);
-                self.handle_container_res(span, result);
+                self.handle_container_res(span, expected_span, result);
             }
             PropertyValueEnum::Optional(option) => {
                 let IrListItem(child) = match child {
                     IrItem::ListItem(item) => item,
                     child => {
                         trace!("\x1b[41moptional value must be list item\x1b[0m");
-                        self.report_wrong_item_shape(&child, parent_type, ItemShape::Value);
+                        self.report_wrong_item_shape(&child, parent_type);
                         return parent;
                     }
                 };
@@ -145,7 +179,7 @@ impl<'a> TypeChecker<'a> {
                         TypeMismatch {
                             span: *child.meta(),
                             expected: RitoType::simple(option.item_kind()),
-                            expected_span: None, // TODO: would be nice here
+                            expected_span,
                             got: child.rito_type().into(),
                         }
                         .unwrap(),
@@ -263,7 +297,9 @@ impl Visitor for TypeChecker<'_> {
                     .or(parent_type.value_subtype())
                     .map(RitoType::simple);
 
-                match resolve_value(&mut self.ctx, ctx, tree, value_hint) {
+                let type_span = parent.type_span();
+
+                match resolve_value(&mut self.ctx, ctx, tree, value_hint, type_span) {
                     Ok(Some(item)) => {
                         trace!("  list item {item:?}");
                         if color_vec_type.is_some() {
@@ -291,7 +327,7 @@ impl Visitor for TypeChecker<'_> {
                                     got,
                                     expected: value_hint
                                         .unwrap_or(RitoType::simple(PropertyKind::None)),
-                                    expected_span: None,
+                                    expected_span: type_span,
                                 }
                                 .unwrap(),
                             );
@@ -307,6 +343,7 @@ impl Visitor for TypeChecker<'_> {
                     ctx,
                     tree,
                     parent.map(|p| p.1.value().rito_type()),
+                    parent.and_then(|p| p.1.type_span()),
                 )
                 .map_err(|e| e.fallback(tree.span))
                 {
@@ -355,7 +392,12 @@ impl Visitor for TypeChecker<'_> {
                 return Visit::Continue;
             }
 
-            if let Err(e) = try_populate_listlike(&mut ir.1, &mut self.list_queue) {
+            // a listlike written as a list item declares no type of its own
+            let type_span =
+                ir.1.type_span()
+                    .or_else(|| self.stack.last().and_then(|(_, parent)| parent.type_span()));
+
+            if let Err(e) = try_populate_listlike(&mut ir.1, &mut self.list_queue, type_span) {
                 self.ctx.diagnostics.push(e.fallback(*ir.1.value().meta()));
             }
 
@@ -371,6 +413,7 @@ impl Visitor for TypeChecker<'_> {
                     let IrItem::Entry(IrEntry {
                         key: key @ PropertyValueEnum::String(values::String { .. }),
                         value,
+                        ..
                     }) = ir.1
                     else {
                         self.ctx

--- a/crates/ltk_ritobin/src/typecheck/walk.rs
+++ b/crates/ltk_ritobin/src/typecheck/walk.rs
@@ -120,7 +120,6 @@ impl<'a> TypeChecker<'a> {
                         self.handle_container_res(span, expected_span, result);
                     }
                     child @ IrItem::Entry(_) => {
-                        trace!("\x1b[41mlist item must be list item\x1b[0m");
                         self.report_wrong_item_shape(&child, parent_type);
                         return parent;
                     }
@@ -131,7 +130,6 @@ impl<'a> TypeChecker<'a> {
                 let IrEntry { key, value, .. } = match child {
                     IrItem::Entry(entry) => entry,
                     child => {
-                        trace!("\x1b[41mstruct item must be entry\x1b[0m");
                         self.report_wrong_item_shape(&child, parent_type);
                         return parent;
                     }
@@ -150,7 +148,6 @@ impl<'a> TypeChecker<'a> {
                 let IrEntry { key, value, .. } = match child {
                     IrItem::Entry(entry) => entry,
                     child => {
-                        trace!("map item must be entry");
                         self.report_wrong_item_shape(&child, parent_type);
                         return parent;
                     }
@@ -169,7 +166,6 @@ impl<'a> TypeChecker<'a> {
                 let IrListItem(child) = match child {
                     IrItem::ListItem(item) => item,
                     child => {
-                        trace!("\x1b[41moptional value must be list item\x1b[0m");
                         self.report_wrong_item_shape(&child, parent_type);
                         return parent;
                     }

--- a/crates/ltk_ritobin/src/types.rs
+++ b/crates/ltk_ritobin/src/types.rs
@@ -133,6 +133,27 @@ impl RitoType {
         self.subtypes[1].or(self.subtypes[0])
     }
 
+    /// Whether this type's `{ .. }` block holds entries or bare values.
+    ///
+    /// `None` for the types that are never written with a block at all.
+    ///
+    /// ```text
+    /// Entry   pointer, embed, map        Foo { bar: u32 = 1 }    map[hash,u32] = { 0x1 = 1 }
+    /// Value   list, list2, option        list[u32] = { 1, 2 }    option[u32] = { 1 }
+    /// Value   vec2/3/4, rgba, mtx44      vec3 = { 1, 2, 3 }
+    /// None    everything else            u32 = 1                 string = "a"
+    /// ```
+    pub fn item_shape(&self) -> Option<ItemShape> {
+        use PropertyKind as K;
+        Some(match self.base {
+            K::Struct | K::Embedded | K::Map => ItemShape::Entry,
+            K::Container | K::UnorderedContainer | K::Optional => ItemShape::Value,
+            // a listlike spells its components out as bare values, `vec3 = { 1, 2, 3 }`
+            K::Vector2 | K::Vector3 | K::Vector4 | K::Color | K::Matrix44 => ItemShape::Value,
+            _ => return None,
+        })
+    }
+
     pub fn make_default<M: Default>(&self, span: M) -> PropertyValueEnum<M> {
         let mut value = match self.base {
             PropertyKind::Map => {
@@ -154,6 +175,26 @@ impl RitoType {
         };
         *value.meta_mut() = span;
         value
+    }
+}
+
+/// The shape an item must have to sit inside a type's `{ .. }` block.
+///
+/// Which one a type wants is fixed by its base kind - see [`RitoType::item_shape`].
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub enum ItemShape {
+    /// `key: type = value` (or `key = value`)
+    Entry,
+    /// a bare value
+    Value,
+}
+
+impl Display for ItemShape {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            ItemShape::Entry => "an entry ('name: type = value')",
+            ItemShape::Value => "a value",
+        })
     }
 }
 


### PR DESCRIPTION
Adds `MissingClassName`, `UnexpectedItem` and `QuotedPropertyName` diagnostics, and
implements `Display` for `Diagnostic` so callers stop rendering `{:?}`.

The `merge_ir` routine previously silently dropped child entries with no diagnostics, only trace events. This PR adds the missing diagnostics so callers can fix the issue on their end.

#### Other stuff
- Implement `Display` for `Diagnostic` so consumers don't have to do it themselves
- Implement `#[non_exhaustive]` on `Diagnostic` so we don't break the API when adding new ones
- Added `Node::open_brace_span` for diagnostics which want to point at the block opening instead of a very long squiggly
- Added `IrItem::shape_span` so complaints about the item's shape point at the key rather than the whole body