### PR TITLE
warn on unwrap usage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,8 @@ criterion = {version = "0.8",  features = ["html_reports"] }
 warnings = "warn"
 
 [workspace.lints.clippy]
+unwrap_used = "warn"
+
 correctness = { level = "deny", priority = -1 }
 suspicious  = { level = "deny", priority = -1 }
 perf        = { level = "warn", priority = -1 }

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+allow-unwrap-in-tests = true


### PR DESCRIPTION
This PR can be merged once it has 0 unwraps that warn in it. **ONLY** commit to this branch to directly remove/allow unwraps, any warnings that need additional feature work to remove should be done in their respective PRs.