### PR TITLE
feat(wad)!: subset extraction, bin name recovery and a reshaped extractor API

### DIFF
--- a/crates/ltk_shader/src/loader.rs
+++ b/crates/ltk_shader/src/loader.rs
@@ -58,12 +58,11 @@ impl ShaderLoader {
 
         let path_hash = xxh64(full_shader_object_path.as_bytes(), 0);
 
-        let chunk =
-            *wad.chunks()
-                .get(path_hash)
-                .ok_or_else(|| ShaderError::ShaderObjectNotFound {
-                    path: full_shader_object_path.clone(),
-                })?;
+        let chunk = *wad.chunks().get(path_hash.into()).ok_or_else(|| {
+            ShaderError::ShaderObjectNotFound {
+                path: full_shader_object_path.clone(),
+            }
+        })?;
 
         let shader_object_data = wad.load_chunk_decompressed(&chunk)?;
         let mut shader_object_reader = Cursor::new(shader_object_data);
@@ -112,7 +111,7 @@ impl ShaderLoader {
             create_shader_bundle_path(full_shader_object_path, shader_bundle_id);
 
         let bundle_path_hash = xxh64(shader_bundle_path.as_bytes(), 0);
-        let bundle_chunk = *wad.chunks().get(bundle_path_hash).ok_or_else(|| {
+        let bundle_chunk = *wad.chunks().get(bundle_path_hash.into()).ok_or_else(|| {
             ShaderError::ShaderBundleNotFound {
                 path: shader_bundle_path.clone(),
             }

--- a/crates/ltk_wad/Cargo.toml
+++ b/crates/ltk_wad/Cargo.toml
@@ -14,7 +14,6 @@ default = ["zstd"]
 
 serde = ["dep:serde"]
 rust_backend = ["flate2/rust_backend", "ruzstd"]
-regex = ["dep:regex"]
 
 zstd = ["dep:zstd"]
 ruzstd = ["dep:ruzstd"]
@@ -39,7 +38,6 @@ serde = { workspace = true, optional = true }
 ltk_io_ext = { version = "0.4.4", path = "../ltk_io_ext" }
 ltk_file = { version = "0.2.10", path = "../ltk_file" }
 
-regex = { version = "1", optional = true }
 camino = { workspace = true }
 
 [dev-dependencies]

--- a/crates/ltk_wad/Cargo.toml
+++ b/crates/ltk_wad/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 [features]
 default = ["zstd"]
 
-serde = ["dep:serde"]
+serde = ["dep:serde", "ltk_hash/serde"]
 rust_backend = ["flate2/rust_backend", "ruzstd"]
 
 zstd = ["dep:zstd"]
@@ -37,6 +37,7 @@ serde = { workspace = true, optional = true }
 
 ltk_io_ext = { version = "0.4.4", path = "../ltk_io_ext" }
 ltk_file = { version = "0.2.10", path = "../ltk_file" }
+ltk_hash = { version = "0.4.0", path = "../ltk_hash" }
 
 camino = { workspace = true }
 

--- a/crates/ltk_wad/Cargo.toml
+++ b/crates/ltk_wad/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.3.1"
 edition = "2021"
 description = "WAD archive reading/writing for League Toolkit"
 license = "MIT OR Apache-2.0"
-readme = "../../README.md"
+readme = "README.md"
 
 [lints]
 workspace = true

--- a/crates/ltk_wad/README.md
+++ b/crates/ltk_wad/README.md
@@ -1,0 +1,235 @@
+# ltk_wad
+
+Reading, extracting and building League of Legends WAD archives, the `.wad.client` files that hold the assets of the game.
+
+- A WAD is a table of chunks followed by their bytes.
+- Each chunk is one file, compressed on its own with gzip or zstd, or stored as is.
+- The archive keeps no file names. The key of a chunk is the xxh64 of its lower-case path, typed as [`WadHash`](https://docs.rs/ltk_hash).
+- A name comes back only through a hash table, such as the one [CommunityDragon](https://github.com/CommunityDragon/Data) maintains, or out of the `.bin` files inside the archive.
+
+The crate supports reading all versions and writing the latest one, and is part of [League Toolkit](https://github.com/LeagueToolkit/league-toolkit). The umbrella crate exposes it as `league_toolkit::wad` behind the `wad` feature.
+
+```toml
+[dependencies]
+ltk_wad = "0.4"
+ltk_hash = "0.4" # to hash paths yourself
+```
+
+## Contents
+
+- [Feature flags](#feature-flags)
+- [Reading an archive](#reading-an-archive)
+- [Naming chunks](#naming-chunks)
+- [Extracting to disk](#extracting-to-disk)
+- [Recovering names from the bins](#recovering-names-from-the-bins)
+- [Building an archive](#building-an-archive)
+- [Signatures](#signatures)
+- [Parallel pipelines](#parallel-pipelines)
+
+## Feature flags
+
+| Feature        | Default | What it does                                                                          |
+| -------------- | ------- | ------------------------------------------------------------------------------------- |
+| `zstd`         | yes     | zstd through the `zstd` crate, which builds the C library                             |
+| `ruzstd`       | no      | zstd in pure Rust, for targets with no C toolchain. Slower, and exclusive with `zstd` |
+| `rust_backend` | no      | `ruzstd` plus the pure Rust backend of `flate2`, so nothing in the crate compiles C   |
+| `serde`        | no      | `Serialize` and `Deserialize` for `Wad`, its chunk table and each chunk               |
+
+## Reading an archive
+
+```rust
+use std::fs::File;
+use ltk_hash::Hash as _;
+use ltk_wad::{Wad, WadHash};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut wad = Wad::mount(File::open("Aatrox.wad.client")?)?;
+    println!("{} chunks", wad.chunks().len());
+
+    // The table is sorted by hash, and a chunk is a few numbers.
+    for chunk in wad.chunks() {
+        println!(
+            "{:016x} {:?} {} bytes",
+            chunk.path_hash, chunk.compression_type, chunk.uncompressed_size
+        );
+    }
+
+    // A lookup takes the hash of the path, and the bytes come back decompressed.
+    let hash = WadHash::hash_str("data/characters/aatrox/aatrox.bin");
+    if let Some(chunk) = wad.chunks().get(hash).copied() {
+        let bytes = wad.load_chunk_decompressed(&chunk)?;
+        println!("{} bytes of bin", bytes.len());
+    }
+    Ok(())
+}
+```
+
+- `Wad::mount` reads the header and the chunk table, and keeps the source open. Any `Read + Seek` is a source.
+- The bytes of a chunk come off the source when you ask for them.
+- `load_chunk_raw` gives the compressed bytes. `decompress_raw` or a `ChunkDecoder` turns them into the file.
+- `Wad` keeps one decoder, so a run of `load_chunk_decompressed` calls pays for one zstd context.
+
+On `WadHash`:
+
+- `WadHash::hash_str` is a method of the `ltk_hash::Hash` trait, which is why the example imports it.
+- A hash you already hold is `WadHash(value)`.
+- `WadHash` parses from its sixteen hex digits with `str::parse`, and prints as hex.
+
+## Naming chunks
+
+Whatever names the chunks is a `PathResolver`: `resolve(hash)` answers the path, or `None` for a hash it has no name for. These are resolvers:
+
+- every `HashMap<WadHash, String>`
+- a reference, a `Box` or an `Arc` of any resolver
+- `NoResolver`, which names nothing
+- `RecoveredNames`, the names read out of the bins, and `over` layers it on top of another resolver
+
+A CommunityDragon hash table is one name per line, as the hash in hex, a space, and the path:
+
+```rust
+use std::collections::HashMap;
+use ltk_wad::WadHash;
+
+let names: HashMap<WadHash, String> = std::fs::read_to_string("hashes.game.txt")?
+    .lines()
+    .filter_map(|line| line.split_once(' '))
+    .filter_map(|(hash, path)| Some((hash.parse().ok()?, path.to_owned())))
+    .collect();
+```
+
+## Extracting to disk
+
+```rust
+use ltk_wad::{ExistingFilePolicy, WadExtractor};
+
+let mut extractor = WadExtractor::new(&names)
+    .with_filter(|path| path.starts_with("assets/characters/"))
+    .with_existing_file_policy(ExistingFilePolicy::Skip)
+    .on_progress(|p| println!("{:5.1}% {}", p.fraction() * 100.0, p.path()));
+
+let report = extractor.extract_all(&mut wad, "out")?;
+println!("{report}");
+```
+
+What the builder takes:
+
+- `with_filter` keeps the chunks whose path the closure accepts. An unnamed chunk shows as its hash.
+- `with_type_filter` keeps only the given `LeagueFileKind`s, by what the bytes identify as.
+- `with_layout(ExtractLayout::Flat)` drops the directories. A second chunk of one name takes `name.<hash>.ext`.
+- `with_existing_file_policy(ExistingFilePolicy::Skip)` leaves a file that exists, and counts it.
+- `on_progress` hears of each chunk once it is done, with the count, the path, the result and the bytes.
+- `with_cancel_flag` takes an `AtomicBool`, and the reader tests it before each chunk.
+- `with_workers` sets the thread count. The default is the parallelism of the machine, capped at eight.
+- `with_name_recovery` reads the bins for the names the resolver lacks. See [below](#recovering-names-from-the-bins).
+
+What it runs:
+
+- `extract_all` extracts every chunk.
+- `extract_chunks` takes the hashes of the chunks to extract, and lists the ones the archive lacks under `report.missing`.
+
+How it runs:
+
+- The reader walks the archive in order on the calling thread.
+- It hands each chunk to a worker over a channel bounded by the worker count, and the worker decompresses and writes it.
+- The resolver, the path filter and the progress callback stay on the calling thread, so none of them needs to be `Sync`.
+
+Where a chunk lands on disk:
+
+| The chunk                                              | Lands at                                                                 |
+| ------------------------------------------------------ | ------------------------------------------------------------------------ |
+| The resolver names it                                  | Its path, with every directory of it                                     |
+| Nothing names it                                       | Its hash as sixteen hex digits, with the extension its bytes identify as |
+| Its name has no extension, or is an existing directory | `<stem>.ltk.<ext>`, or `<stem>.ltk` when the bytes identify as nothing   |
+| Its name is too long for the file system               | `<hash>.<ext>` in the output directory itself                            |
+
+What comes back:
+
+- An `ExtractReport` counts the chunks written, skipped and missing, the bytes, and the chunks by kind. It prints as one line.
+- A chunk that fails to read, decompress or write fails the extraction with `WadError::Chunk`, which wraps the cause with the hash and the path of the chunk.
+
+## Recovering names from the bins
+
+The `.bin` files of League name the assets they use by path. So the names of many chunks a hash table lacks sit inside the archive itself. `with_name_recovery()` reads them out before the extraction writes anything:
+
+```rust
+let report = WadExtractor::new(&names)
+    .with_name_recovery()
+    .extract_all(&mut wad, "out")?;
+println!(
+    "{} names from {} bins",
+    report.recovered.len(),
+    report.recovered.bins_scanned
+);
+```
+
+A match is exact: a string counts only when its hash is the hash of a chunk the resolver could not name. The pass stays cheap:
+
+- Nothing runs when the resolver names every chunk.
+- The scan finds a bin by its name, or by its first bytes, which it decodes from the first compressed block alone.
+- It reads the strings out as the length-prefixed runs the format writes, with no parse of the object tree.
+- The bins decompress on the worker threads.
+
+On an archive of 30,000 chunks the pass takes tens of milliseconds with a hash table, and under a second with none. `NameRecovery` runs the same scan on its own, and returns the `RecoveredNames`.
+
+## Building an archive
+
+```rust
+use std::io::{Cursor, Write as _};
+use ltk_wad::{WadBuilder, WadChunkBuilder, WadChunkCompression};
+
+let mut out = Cursor::new(Vec::new());
+WadBuilder::default()
+    .with_chunk(WadChunkBuilder::default().with_path("data/characters/aatrox/aatrox.bin"))
+    .with_chunk(
+        WadChunkBuilder::default()
+            .with_path("assets/characters/aatrox/skins/base/aatrox_base_tx_cm.dds")
+            .with_force_compression(WadChunkCompression::None),
+    )
+    .build_to_writer(&mut out, |path_hash, cursor| {
+        // The bytes of the chunk at `path_hash`, from wherever they live.
+        cursor.write_all(&bytes_for(path_hash))?;
+        Ok(())
+    })?;
+```
+
+- The builder writes the chunks in hash order, which the game requires.
+- It picks the compression of each chunk by what its bytes identify as, unless `with_force_compression` says otherwise.
+- `with_path` hashes a path for the chunk, and `with_hash` takes a hash you already hold.
+- `with_prebuilt_signature` and `with_prebuilt_checksum` keep the header of a mounted archive, for a byte-identical rebuild.
+
+## Signatures
+
+Riot signs the chunk table. `verify_signature` checks the embedded PKCS#1 v1.5 signature over the SHA-256 of the table, and `RITO_PKEY` is the public key of Riot:
+
+```rust
+use ltk_wad::rsa::{pkcs8::DecodePublicKey as _, RsaPublicKey};
+use ltk_wad::RITO_PKEY;
+
+let key = RsaPublicKey::from_public_key_der(RITO_PKEY)?;
+let (valid, toc_sha256) = wad.verify_signature(&key)?;
+```
+
+## Parallel pipelines
+
+`load_chunk_raw` and `decompress_raw` split the I/O from the CPU work, so a pipeline reads the archive in order and decompresses wherever it likes:
+
+```rust
+use ltk_wad::{decompress_raw, WadChunk};
+
+let chunks: Vec<WadChunk> = wad.chunks().iter().copied().collect();
+for chunk in &chunks {
+    let raw = wad.load_chunk_raw(chunk)?;
+    // This can run on another thread. `wad` is not borrowed.
+    let bytes = decompress_raw(&raw, chunk.compression_type, chunk.uncompressed_size)?;
+}
+```
+
+Three ways to decode:
+
+- `decompress_raw` decodes one chunk, and builds a zstd context for it.
+- `ChunkDecoder` keeps one zstd context between chunks, the right tool for a thread that decodes many.
+- `decompress_prefix`, on either, decodes the first bytes of a chunk alone from a prefix of its raw bytes, enough to tell its kind.
+
+## License
+
+MIT OR Apache-2.0, at your option.

--- a/crates/ltk_wad/src/builder.rs
+++ b/crates/ltk_wad/src/builder.rs
@@ -7,6 +7,7 @@ use ltk_io_ext::measure;
 use xxhash_rust::xxh3;
 
 use ltk_file::LeagueFileKind;
+use ltk_hash::{Hash as _, WadHash};
 
 use crate::FileExt as _;
 
@@ -95,7 +96,7 @@ impl WadBuilder {
     /// * `provide_chunk_data` - A function that provides the rawdata for each chunk.
     pub fn build_to_writer<
         TWriter: io::Write + io::Seek,
-        TChunkDataProvider: Fn(u64, &mut Cursor<Vec<u8>>) -> Result<(), WadBuilderError>,
+        TChunkDataProvider: Fn(WadHash, &mut Cursor<Vec<u8>>) -> Result<(), WadBuilderError>,
     >(
         self,
         writer: &mut TWriter,
@@ -253,8 +254,7 @@ impl WadBuilder {
 /// ```
 #[derive(Debug, Clone, Copy, Default)]
 pub struct WadChunkBuilder {
-    /// The path hash of the chunk. Hashed using xxhash64.
-    path: u64,
+    path: WadHash,
 
     /// If provided, the chunk will be compressed using the given compression type, otherwise the ideal compression will be used.
     force_compression: Option<WadChunkCompression>,
@@ -265,15 +265,15 @@ impl WadChunkBuilder {
     ///
     /// If you already have the hash itself, see [`with_hash`](Self::with_hash).
     pub fn with_path(mut self, path: impl AsRef<str>) -> Self {
-        self.path = crate::hash_wad_path(path.as_ref());
+        self.path = WadHash::hash_str(path);
         self
     }
 
     /// Set the chunk path hash directly.
     ///
     /// If you have the actual path instead of the hash, see [`with_path`](Self::with_path)
-    pub fn with_hash(mut self, hash: u64) -> Self {
-        self.path = hash;
+    pub fn with_hash(mut self, hash: impl Into<WadHash>) -> Self {
+        self.path = hash.into();
         self
     }
 
@@ -326,8 +326,8 @@ mod tests {
         let toc_sha256: [u8; 32] = Sha256::digest(toc).into();
         assert_eq!(wad.toc_sha256().unwrap(), toc_sha256);
 
-        let chunk = wad.chunks().get(crate::hash_wad_path("test1")).unwrap();
-        assert_eq!(chunk.path_hash, crate::hash_wad_path("test1"));
+        let chunk = wad.chunks().get(WadHash::hash_str("test1")).unwrap();
+        assert_eq!(chunk.path_hash, WadHash::hash_str("test1"));
         assert_eq!(chunk.compressed_size, 17);
         assert_eq!(chunk.uncompressed_size, 100);
         assert_eq!(chunk.compression_type, WadChunkCompression::Zstd);

--- a/crates/ltk_wad/src/builder.rs
+++ b/crates/ltk_wad/src/builder.rs
@@ -4,7 +4,7 @@ use byteorder::{WriteBytesExt, LE};
 use flate2::read::GzEncoder;
 use itertools::Itertools;
 use ltk_io_ext::measure;
-use xxhash_rust::{xxh3, xxh64};
+use xxhash_rust::xxh3;
 
 use ltk_file::LeagueFileKind;
 
@@ -265,7 +265,7 @@ impl WadChunkBuilder {
     ///
     /// If you already have the hash itself, see [`with_hash`](Self::with_hash).
     pub fn with_path(mut self, path: impl AsRef<str>) -> Self {
-        self.path = xxh64::xxh64(path.as_ref().to_lowercase().as_bytes(), 0);
+        self.path = crate::hash_wad_path(path.as_ref());
         self
     }
 
@@ -326,8 +326,8 @@ mod tests {
         let toc_sha256: [u8; 32] = Sha256::digest(toc).into();
         assert_eq!(wad.toc_sha256().unwrap(), toc_sha256);
 
-        let chunk = wad.chunks().get(xxh64::xxh64(b"test1", 0)).unwrap();
-        assert_eq!(chunk.path_hash, xxh64::xxh64(b"test1", 0));
+        let chunk = wad.chunks().get(crate::hash_wad_path("test1")).unwrap();
+        assert_eq!(chunk.path_hash, crate::hash_wad_path("test1"));
         assert_eq!(chunk.compressed_size, 17);
         assert_eq!(chunk.uncompressed_size, 100);
         assert_eq!(chunk.compression_type, WadChunkCompression::Zstd);

--- a/crates/ltk_wad/src/chunk.rs
+++ b/crates/ltk_wad/src/chunk.rs
@@ -2,6 +2,7 @@ use std::io::{BufReader, Read};
 use std::{fmt, io};
 
 use byteorder::{ReadBytesExt as _, WriteBytesExt as _, LE};
+use ltk_hash::WadHash;
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 
 use super::WadError;
@@ -33,7 +34,7 @@ impl fmt::Display for WadChunkCompression {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 /// A single wad chunk
 pub struct WadChunk {
-    pub path_hash: u64,
+    pub path_hash: WadHash,
     pub data_offset: usize,
     pub compressed_size: usize,
     pub uncompressed_size: usize,
@@ -46,7 +47,7 @@ pub struct WadChunk {
 
 impl WadChunk {
     pub fn read_v3_1<R: Read>(reader: &mut BufReader<R>) -> Result<WadChunk, WadError> {
-        let path_hash = reader.read_u64::<LE>()?;
+        let path_hash = WadHash(reader.read_u64::<LE>()?);
         let data_offset = reader.read_u32::<LE>()? as usize;
         let compressed_size = reader.read_i32::<LE>()? as usize;
         let uncompressed_size = reader.read_i32::<LE>()? as usize;
@@ -76,7 +77,7 @@ impl WadChunk {
     }
 
     pub fn read_v3_4<R: Read>(reader: &mut BufReader<R>) -> Result<WadChunk, WadError> {
-        let path_hash = reader.read_u64::<LE>()?;
+        let path_hash = WadHash(reader.read_u64::<LE>()?);
         let data_offset = reader.read_u32::<LE>()? as usize;
         let compressed_size = reader.read_u32::<LE>()? as usize;
         let uncompressed_size = reader.read_u32::<LE>()? as usize;
@@ -106,7 +107,7 @@ impl WadChunk {
     }
 
     pub fn write_v3_4<W: io::Write>(&self, writer: &mut W) -> Result<(), WadError> {
-        writer.write_u64::<LE>(self.path_hash)?;
+        writer.write_u64::<LE>(self.path_hash.0)?;
         writer.write_u32::<LE>(self.data_offset as u32)?;
         writer.write_u32::<LE>(self.compressed_size as u32)?;
         writer.write_u32::<LE>(self.uncompressed_size as u32)?;
@@ -121,7 +122,7 @@ impl WadChunk {
         Ok(())
     }
 
-    pub fn path_hash(&self) -> u64 {
+    pub fn path_hash(&self) -> WadHash {
         self.path_hash
     }
     pub fn data_offset(&self) -> usize {

--- a/crates/ltk_wad/src/chunks.rs
+++ b/crates/ltk_wad/src/chunks.rs
@@ -1,5 +1,7 @@
 use std::collections::HashMap;
 
+use ltk_hash::WadHash;
+
 use super::WadChunk;
 
 /// An ordered collection of WAD chunks, sorted by path hash.
@@ -10,7 +12,7 @@ pub struct WadChunks {
     chunks: Vec<WadChunk>,
     /// Maps `path_hash` to index in `chunks`.
     #[cfg_attr(feature = "serde", serde(skip))]
-    index: HashMap<u64, usize>,
+    index: HashMap<WadHash, usize>,
 }
 
 impl WadChunks {
@@ -41,7 +43,7 @@ impl WadChunks {
     }
 
     /// Look up a chunk by its path hash.
-    pub fn get(&self, path_hash: u64) -> Option<&WadChunk> {
+    pub fn get(&self, path_hash: WadHash) -> Option<&WadChunk> {
         self.index.get(&path_hash).map(|&i| &self.chunks[i])
     }
 
@@ -56,7 +58,7 @@ impl WadChunks {
     }
 
     /// Returns `true` if a chunk with the given path hash exists.
-    pub fn contains(&self, path_hash: u64) -> bool {
+    pub fn contains(&self, path_hash: WadHash) -> bool {
         self.index.contains_key(&path_hash)
     }
 }

--- a/crates/ltk_wad/src/decoder.rs
+++ b/crates/ltk_wad/src/decoder.rs
@@ -93,11 +93,11 @@ fn decompress_zstd_multi(raw_data: &[u8], uncompressed_size: usize) -> Result<Bo
 /// Decompresses at most `max_len` bytes from the start of a chunk's raw data.
 ///
 /// `raw_data` may be a prefix of the chunk's raw bytes. As long as it holds
-/// the first compressed block, the first bytes decode, which is what a read
-/// of a chunk's magic wants without the rest of the chunk. A prefix that cuts
+/// the first compressed block, the first bytes decode. That is all a read of
+/// a chunk's magic wants, without the rest of the chunk. A prefix that cuts
 /// the first block short fails to decode.
 ///
-/// For [`WadChunkCompression::None`], the prefix of the input is returned as is.
+/// For [`WadChunkCompression::None`], the prefix of the input comes back as is.
 pub fn decompress_prefix(
     raw_data: &[u8],
     compression: WadChunkCompression,
@@ -264,7 +264,7 @@ impl ChunkDecoder {
         Ok(data)
     }
 
-    /// Decode frames from `input` into `output` until one of them runs out.
+    /// Decode frames from `input` into `output` until one of them ends.
     ///
     /// Returns the bytes written. Input that ends mid-block is not an error
     /// here, because a prefix read does that on purpose.

--- a/crates/ltk_wad/src/decoder.rs
+++ b/crates/ltk_wad/src/decoder.rs
@@ -1,4 +1,7 @@
-use std::io::{Cursor, Read};
+use std::{
+    fmt,
+    io::{Cursor, Read},
+};
 
 use super::{WadChunkCompression, WadError};
 use flate2::read::GzDecoder;
@@ -62,7 +65,6 @@ fn decompress_zstd_multi(raw_data: &[u8], uncompressed_size: usize) -> Result<Bo
 
     let zstd_magic_offset =
         memmem::find(raw_data, &ZSTD_MAGIC).ok_or(WadError::DecompressionFailure {
-            path_hash: 0,
             reason: String::from("failed to find zstd magic"),
         })?;
 
@@ -137,7 +139,6 @@ fn zstd_reader(raw_data: &[u8]) -> Result<impl Read + '_, WadError> {
 fn zstd_reader(raw_data: &[u8]) -> Result<impl Read + '_, WadError> {
     ruzstd::decoding::StreamingDecoder::new(Cursor::new(raw_data)).map_err(|error| {
         WadError::DecompressionFailure {
-            path_hash: 0,
             reason: error.to_string(),
         }
     })
@@ -162,6 +163,12 @@ pub struct ChunkDecoder {
     zstd: Option<zstd::zstd_safe::DCtx<'static>>,
 }
 
+impl fmt::Debug for ChunkDecoder {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ChunkDecoder").finish_non_exhaustive()
+    }
+}
+
 impl ChunkDecoder {
     /// A decoder with nothing built yet. The first zstd chunk builds the context.
     pub fn new() -> Self {
@@ -183,7 +190,6 @@ impl ChunkDecoder {
             WadChunkCompression::ZstdMulti => {
                 let frame_at = memmem::find(raw_data, &ZSTD_MAGIC).ok_or_else(|| {
                     WadError::DecompressionFailure {
-                        path_hash: 0,
                         reason: String::from("failed to find zstd magic"),
                     }
                 })?;
@@ -230,7 +236,6 @@ impl ChunkDecoder {
         let written = self.stream_into(&raw_data[frame_at..], &mut data[copied..])?;
         if copied + written != uncompressed_size {
             return Err(WadError::DecompressionFailure {
-                path_hash: 0,
                 reason: format!(
                     "decompressed {} bytes, expected {uncompressed_size}",
                     copied + written
@@ -290,7 +295,6 @@ impl ChunkDecoder {
 #[cfg(feature = "zstd")]
 fn zstd_error(code: zstd::zstd_safe::ErrorCode) -> WadError {
     WadError::DecompressionFailure {
-        path_hash: 0,
         reason: zstd::zstd_safe::get_error_name(code).to_owned(),
     }
 }

--- a/crates/ltk_wad/src/decoder.rs
+++ b/crates/ltk_wad/src/decoder.rs
@@ -87,3 +87,210 @@ fn decompress_zstd_multi(raw_data: &[u8], uncompressed_size: usize) -> Result<Bo
 
     Ok(data.into_boxed_slice())
 }
+
+/// Decompresses at most `max_len` bytes from the start of a chunk's raw data.
+///
+/// `raw_data` may be a prefix of the chunk's raw bytes. As long as it holds
+/// the first compressed block, the first bytes decode, which is what a read
+/// of a chunk's magic wants without the rest of the chunk. A prefix that cuts
+/// the first block short fails to decode.
+///
+/// For [`WadChunkCompression::None`], the prefix of the input is returned as is.
+pub fn decompress_prefix(
+    raw_data: &[u8],
+    compression: WadChunkCompression,
+    max_len: usize,
+) -> Result<Vec<u8>, WadError> {
+    match compression {
+        WadChunkCompression::None => Ok(raw_data[..raw_data.len().min(max_len)].to_vec()),
+        WadChunkCompression::GZip => read_prefix(GzDecoder::new(Cursor::new(raw_data)), max_len),
+        WadChunkCompression::Satellite => Err(WadError::Other(String::from(
+            "satellite chunks are not supported",
+        ))),
+        WadChunkCompression::Zstd => read_prefix(zstd_reader(raw_data)?, max_len),
+        WadChunkCompression::ZstdMulti => {
+            /* The bytes before the first frame are stored raw, so they are the
+            prefix until the frame starts. */
+            let frame_at = memmem::find(raw_data, &ZSTD_MAGIC).unwrap_or(raw_data.len());
+            let mut data = raw_data[..frame_at.min(max_len)].to_vec();
+            if data.len() < max_len && frame_at < raw_data.len() {
+                let rest = read_prefix(zstd_reader(&raw_data[frame_at..])?, max_len - data.len())?;
+                data.extend(rest);
+            }
+            Ok(data)
+        }
+    }
+}
+
+fn read_prefix(reader: impl Read, max_len: usize) -> Result<Vec<u8>, WadError> {
+    let mut data = Vec::with_capacity(max_len);
+    reader.take(max_len as u64).read_to_end(&mut data)?;
+    Ok(data)
+}
+
+#[cfg(feature = "zstd")]
+fn zstd_reader(raw_data: &[u8]) -> Result<impl Read + '_, WadError> {
+    Ok(zstd::Decoder::new(Cursor::new(raw_data))?)
+}
+
+#[cfg(all(feature = "ruzstd", not(feature = "zstd")))]
+fn zstd_reader(raw_data: &[u8]) -> Result<impl Read + '_, WadError> {
+    ruzstd::decoding::StreamingDecoder::new(Cursor::new(raw_data)).map_err(|error| {
+        WadError::DecompressionFailure {
+            path_hash: 0,
+            reason: error.to_string(),
+        }
+    })
+}
+
+#[cfg(not(any(feature = "zstd", feature = "ruzstd")))]
+fn zstd_reader(_raw_data: &[u8]) -> Result<std::io::Empty, WadError> {
+    Err(WadError::Other(String::from("zstd support is not enabled")))
+}
+
+/// A chunk decompressor that keeps its decoder between chunks.
+///
+/// A zstd decoder is a context of a few hundred kilobytes, and building one
+/// costs about as much as decoding a small chunk. One per thread, kept across
+/// chunks, pays for it once. [`decompress_raw`] and [`decompress_prefix`]
+/// build one per call, which is the right trade for a single chunk.
+///
+/// Without the `zstd` feature the methods are the free functions.
+#[derive(Default)]
+pub struct ChunkDecoder {
+    #[cfg(feature = "zstd")]
+    zstd: Option<zstd::zstd_safe::DCtx<'static>>,
+}
+
+impl ChunkDecoder {
+    /// A decoder with nothing built yet. The first zstd chunk builds the context.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Decompress a whole chunk. The same as [`decompress_raw`], with the decoder kept.
+    pub fn decompress(
+        &mut self,
+        raw_data: &[u8],
+        compression: WadChunkCompression,
+        uncompressed_size: usize,
+    ) -> Result<Box<[u8]>, WadError> {
+        #[cfg(feature = "zstd")]
+        match compression {
+            WadChunkCompression::Zstd => {
+                return self.decompress_zstd(raw_data, 0, uncompressed_size)
+            }
+            WadChunkCompression::ZstdMulti => {
+                let frame_at = memmem::find(raw_data, &ZSTD_MAGIC).ok_or_else(|| {
+                    WadError::DecompressionFailure {
+                        path_hash: 0,
+                        reason: String::from("failed to find zstd magic"),
+                    }
+                })?;
+                return self.decompress_zstd(raw_data, frame_at, uncompressed_size);
+            }
+            _ => {}
+        }
+        decompress_raw(raw_data, compression, uncompressed_size)
+    }
+
+    /// Decompress at most `max_len` bytes from the start of a chunk.
+    ///
+    /// The same as [`decompress_prefix`], with the decoder kept. A prefix that
+    /// cuts the first block short comes back shorter than `max_len` rather than
+    /// as an error, so a caller can tell it to read more.
+    pub fn decompress_prefix(
+        &mut self,
+        raw_data: &[u8],
+        compression: WadChunkCompression,
+        max_len: usize,
+    ) -> Result<Vec<u8>, WadError> {
+        #[cfg(feature = "zstd")]
+        match compression {
+            WadChunkCompression::Zstd => return self.decompress_zstd_prefix(raw_data, 0, max_len),
+            WadChunkCompression::ZstdMulti => {
+                let frame_at = memmem::find(raw_data, &ZSTD_MAGIC).unwrap_or(raw_data.len());
+                return self.decompress_zstd_prefix(raw_data, frame_at, max_len);
+            }
+            _ => {}
+        }
+        decompress_prefix(raw_data, compression, max_len)
+    }
+
+    #[cfg(feature = "zstd")]
+    fn decompress_zstd(
+        &mut self,
+        raw_data: &[u8],
+        frame_at: usize,
+        uncompressed_size: usize,
+    ) -> Result<Box<[u8]>, WadError> {
+        let mut data = vec![0; uncompressed_size];
+        let copied = frame_at.min(uncompressed_size);
+        data[..copied].copy_from_slice(&raw_data[..copied]);
+        let written = self.stream_into(&raw_data[frame_at..], &mut data[copied..])?;
+        if copied + written != uncompressed_size {
+            return Err(WadError::DecompressionFailure {
+                path_hash: 0,
+                reason: format!(
+                    "decompressed {} bytes, expected {uncompressed_size}",
+                    copied + written
+                ),
+            });
+        }
+        Ok(data.into_boxed_slice())
+    }
+
+    #[cfg(feature = "zstd")]
+    fn decompress_zstd_prefix(
+        &mut self,
+        raw_data: &[u8],
+        frame_at: usize,
+        max_len: usize,
+    ) -> Result<Vec<u8>, WadError> {
+        let mut data = vec![0; max_len];
+        let copied = frame_at.min(max_len);
+        data[..copied].copy_from_slice(&raw_data[..copied]);
+        let written = if frame_at < raw_data.len() {
+            self.stream_into(&raw_data[frame_at..], &mut data[copied..])?
+        } else {
+            0
+        };
+        data.truncate(copied + written);
+        Ok(data)
+    }
+
+    /// Decode frames from `input` into `output` until one of them runs out.
+    ///
+    /// Returns the bytes written. Input that ends mid-block is not an error
+    /// here, because a prefix read does that on purpose.
+    #[cfg(feature = "zstd")]
+    fn stream_into(&mut self, input: &[u8], output: &mut [u8]) -> Result<usize, WadError> {
+        use zstd::zstd_safe::{InBuffer, OutBuffer, ResetDirective};
+
+        let context = self.zstd.get_or_insert_with(zstd::zstd_safe::DCtx::create);
+        context
+            .reset(ResetDirective::SessionOnly)
+            .map_err(zstd_error)?;
+
+        let mut input = InBuffer::around(input);
+        let mut output = OutBuffer::around(output);
+        while output.pos() < output.capacity() && input.pos() < input.src.len() {
+            let before = (input.pos(), output.pos());
+            context
+                .decompress_stream(&mut output, &mut input)
+                .map_err(zstd_error)?;
+            if (input.pos(), output.pos()) == before {
+                break;
+            }
+        }
+        Ok(output.pos())
+    }
+}
+
+#[cfg(feature = "zstd")]
+fn zstd_error(code: zstd::zstd_safe::ErrorCode) -> WadError {
+    WadError::DecompressionFailure {
+        path_hash: 0,
+        reason: zstd::zstd_safe::get_error_name(code).to_owned(),
+    }
+}

--- a/crates/ltk_wad/src/error.rs
+++ b/crates/ltk_wad/src/error.rs
@@ -1,5 +1,6 @@
 use std::io;
 
+use ltk_hash::WadHash;
 use thiserror::Error;
 
 /// What can go wrong with a WAD archive.
@@ -19,8 +20,8 @@ pub enum WadError {
     InvalidChunkCompression { compression: u8 },
 
     /// Two chunks share one path hash.
-    #[error("duplicate chunk: {path_hash:#08x}")]
-    DuplicateChunk { path_hash: u64 },
+    #[error("duplicate chunk: {path_hash:016x}")]
+    DuplicateChunk { path_hash: WadHash },
 
     /// A chunk's bytes do not decompress.
     #[error("failed to decompress chunk: {reason}")]
@@ -37,7 +38,7 @@ pub enum WadError {
     /// path is the resolver's, or the hash as sixteen hex digits.
     #[error("chunk {path_hash:016x} ({path}): {source}")]
     Chunk {
-        path_hash: u64,
+        path_hash: WadHash,
         path: String,
         #[source]
         source: Box<WadError>,
@@ -50,7 +51,7 @@ pub enum WadError {
 
 impl WadError {
     /// `source`, as the failure of the chunk at `path`.
-    pub(crate) fn chunk(path_hash: u64, path: &str, source: WadError) -> Self {
+    pub(crate) fn chunk(path_hash: WadHash, path: &str, source: WadError) -> Self {
         Self::Chunk {
             path_hash,
             path: path.to_owned(),

--- a/crates/ltk_wad/src/error.rs
+++ b/crates/ltk_wad/src/error.rs
@@ -2,26 +2,59 @@ use std::io;
 
 use thiserror::Error;
 
+/// What can go wrong with a WAD archive.
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum WadError {
+    /// The file does not start with the WAD magic.
     #[error("invalid header")]
     InvalidHeader { expected: String, actual: String },
 
+    /// The file is a WAD of a version this crate does not read.
     #[error("invalid version {major:?}.{minor:?}")]
     InvalidVersion { major: u8, minor: u8 },
 
+    /// A chunk names a compression this crate does not know.
     #[error("invalid chunk compression: {compression:?}")]
     InvalidChunkCompression { compression: u8 },
 
+    /// Two chunks share one path hash.
     #[error("duplicate chunk: {path_hash:#08x}")]
     DuplicateChunk { path_hash: u64 },
 
-    #[error("failed to decompress chunk (path: {path_hash:#08x}, reason: {reason:?})")]
-    DecompressionFailure { path_hash: u64, reason: String },
+    /// A chunk's bytes do not decompress.
+    #[error("failed to decompress chunk: {reason}")]
+    DecompressionFailure { reason: String },
 
-    #[error("io error")]
+    /// The source or the output could not be read or written.
+    #[error("io error: {0}")]
     IoError(#[from] io::Error),
 
+    /// A failure of one chunk, with the chunk it was.
+    ///
+    /// The extractor and the name recovery wrap every per-chunk failure in
+    /// this, so an error out of an archive of thousands names its chunk. The
+    /// path is the resolver's, or the hash as sixteen hex digits.
+    #[error("chunk {path_hash:016x} ({path}): {source}")]
+    Chunk {
+        path_hash: u64,
+        path: String,
+        #[source]
+        source: Box<WadError>,
+    },
+
+    /// Anything else.
     #[error("error: `{0}`")]
     Other(String),
+}
+
+impl WadError {
+    /// `source`, as the failure of the chunk at `path`.
+    pub(crate) fn chunk(path_hash: u64, path: &str, source: WadError) -> Self {
+        Self::Chunk {
+            path_hash,
+            path: path.to_owned(),
+            source: Box::new(source),
+        }
+    }
 }

--- a/crates/ltk_wad/src/extractor.rs
+++ b/crates/ltk_wad/src/extractor.rs
@@ -47,14 +47,14 @@
 //!
 //! # How a chunk is named on disk
 //!
-//! - A path the resolver knows is used as is.
-//! - A chunk the resolver has no name for is written under its hash as sixteen
-//!   hex digits, with the extension its bytes identify as, when they identify
+//! - A path the resolver knows stays as it is.
+//! - A chunk the resolver has no name for lands under its hash as sixteen hex
+//!   digits. The extension is the one its bytes identify as, when they identify
 //!   as anything.
 //! - A path with no extension, or one that collides with an existing directory,
 //!   becomes `<stem>.ltk.<ext>`, or `<stem>.ltk` when the bytes identify as nothing.
-//! - A name the file system refuses as too long falls back to `<hash>.<ext>` in
-//!   the output directory itself.
+//! - A name the file system refuses as too long becomes `<hash>.<ext>` in the
+//!   output directory itself.
 //!
 //! A chunk no resolver names can still get its name from the archive itself.
 //! [`WadExtractor::with_name_recovery`] reads the `.bin` files for it first.
@@ -65,8 +65,8 @@
 //! [`extract_all`](WadExtractor::extract_all) and
 //! [`extract_chunks`](WadExtractor::extract_chunks) read the archive in order on
 //! the calling thread and hand each chunk to a worker that decompresses and
-//! writes it. The channel between the two is bounded by the worker count, so
-//! memory holds a few chunks whatever the archive holds. The resolver, the path
+//! writes it. The worker count bounds the channel between the two, so memory
+//! holds a few chunks whatever the archive holds. The resolver, the path
 //! filter and the progress callback run on the calling thread only, so none of
 //! them needs to be [`Sync`]. The progress callback hears of each chunk once
 //! the chunk is done.
@@ -96,8 +96,8 @@ use crate::{ChunkDecoder, NameRecovery, RecoveredNames, Wad, WadChunk, WadError}
 ///
 /// A WAD stores the hash of each chunk's path and not the path. A resolver
 /// supplies the path, from a hash table or any other source, and answers
-/// `None` for a hash it has no name for. Such a chunk is written under its
-/// hash as sixteen hex digits.
+/// `None` for a hash it has no name for. The extractor writes such a chunk
+/// under its hash as sixteen hex digits.
 ///
 /// Every `HashMap<WadHash, String>` is a resolver, and so is a reference, a `Box`
 /// or an `Arc` of any resolver.
@@ -155,7 +155,7 @@ impl<S: BuildHasher> PathResolver for HashMap<WadHash, String, S> {
     }
 }
 
-/// A resolver that names nothing, so every chunk is written under its hash.
+/// A resolver that names nothing, so every chunk lands under its hash.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct NoResolver;
 
@@ -169,7 +169,7 @@ impl PathResolver for NoResolver {
     }
 }
 
-/// A path hash as the sixteen hex digits a nameless chunk is written under.
+/// A path hash as the sixteen hex digits a nameless chunk lands under.
 pub(crate) fn hex_name(path_hash: WadHash) -> String {
     format!("{path_hash:016x}")
 }
@@ -191,7 +191,7 @@ impl ExtractProgress<'_> {
         self.done
     }
 
-    /// Chunks the extraction set out to do.
+    /// Chunks the extraction covers, done or not.
     pub fn total(&self) -> usize {
         self.total
     }
@@ -251,9 +251,9 @@ pub enum ExtractLayout {
     Paths,
     /// In the output directory itself, by its file name alone.
     ///
-    /// When two chunks of one extraction share a name, the second keeps apart
-    /// with its path hash before the extension, as `name.<hash>.ext`. Which of
-    /// the two is second follows write order.
+    /// When two chunks of one extraction share a name, the second takes its
+    /// path hash before the extension, as `name.<hash>.ext`. Which of the two
+    /// is second follows write order.
     Flat,
 }
 
@@ -266,8 +266,8 @@ pub enum ExistingFilePolicy {
     Overwrite,
     /// Leave it, and count the chunk under [`ExtractReport::skipped_existing`].
     ///
-    /// The file is opened with `create_new`, so a file that appears between two
-    /// chunks is left alone too and no check races the write.
+    /// The worker opens the file with `create_new`, so it leaves a file that
+    /// appears between two chunks alone too, and no check races the write.
     Skip,
 }
 
@@ -288,7 +288,7 @@ pub struct ExtractReport {
     pub bytes_written: u64,
     /// Written chunks, by the kind their bytes identify as.
     pub by_kind: BTreeMap<LeagueFileKind, usize>,
-    /// The cancel flag was set, so some chunks were never read.
+    /// The cancel flag was set, so the reader never reached some chunks.
     pub cancelled: bool,
     /// What [`with_name_recovery`](WadExtractor::with_name_recovery) read out
     /// of the archive's bins. Empty when recovery was off.
@@ -376,8 +376,8 @@ type ProgressCallback<'a> = Box<dyn FnMut(&ExtractProgress<'_>) + 'a>;
 
 /// Configuration and execution of WAD chunk extraction.
 ///
-/// Build one with [`new`](Self::new), set it up with the `with_*` methods, and
-/// run it with [`extract_all`](Self::extract_all) or
+/// Build one with [`new`](Self::new), configure it with the `with_*` methods,
+/// and run it with [`extract_all`](Self::extract_all) or
 /// [`extract_chunks`](Self::extract_chunks). One extractor runs any number of
 /// extractions.
 pub struct WadExtractor<'a> {
@@ -463,8 +463,8 @@ impl<'a> WadExtractor<'a> {
 
     /// Stop early once `flag` reads `true`.
     ///
-    /// The flag is read before each chunk is read from the archive. Chunks
-    /// already handed to a worker still land, and
+    /// The reader checks the flag before it reads each chunk from the archive.
+    /// Chunks already handed to a worker still land, and
     /// [`ExtractReport::cancelled`] reports the stop.
     pub fn with_cancel_flag(mut self, flag: &'a AtomicBool) -> Self {
         self.cancel = Some(flag);
@@ -480,7 +480,7 @@ impl<'a> WadExtractor<'a> {
     }
 
     /// Read the archive's `.bin` files for the names of chunks the resolver
-    /// cannot name, before anything is written.
+    /// cannot name, before the extraction writes anything.
     ///
     /// Read [`NameRecovery`] for what it costs and what it finds. The names
     /// land in [`ExtractReport::recovered`], and the extraction uses the same
@@ -494,7 +494,7 @@ impl<'a> WadExtractor<'a> {
     ///
     /// # Errors
     ///
-    /// Fails on the first chunk that cannot be read, decompressed or written,
+    /// Fails on the first chunk the extractor cannot read, decompress or write,
     /// with a [`WadError::Chunk`] that names it. Chunks written before it stay
     /// on disk.
     pub fn extract_all<S: Read + Seek>(
@@ -509,12 +509,12 @@ impl<'a> WadExtractor<'a> {
     /// Extract the chunks of `wad` with the given path hashes into
     /// `output_dir`, in the order given.
     ///
-    /// A hash given twice is extracted once. A hash the archive holds no chunk
-    /// for is listed under [`ExtractReport::missing`] and is not an error.
+    /// A hash given twice counts once. A hash the archive holds no chunk for
+    /// lands under [`ExtractReport::missing`] and is not an error.
     ///
     /// # Errors
     ///
-    /// Fails on the first chunk that cannot be read, decompressed or written,
+    /// Fails on the first chunk the extractor cannot read, decompress or write,
     /// with a [`WadError::Chunk`] that names it. Chunks written before it stay
     /// on disk.
     pub fn extract_chunks<S: Read + Seek>(
@@ -745,8 +745,8 @@ impl Shared<'_> {
 
     /// Take jobs until every sender is gone.
     ///
-    /// After a failure the jobs are drained and dropped rather than written,
-    /// so a reader blocked on a full channel gets to see the failure too.
+    /// After a failure the worker drains and drops the jobs rather than writes
+    /// them, so a reader blocked on a full channel sees the failure too.
     fn run_worker(&self, receiver: &Mutex<mpsc::Receiver<Job>>, done: &mpsc::Sender<Done>) {
         let mut decoder = ChunkDecoder::new();
         loop {
@@ -780,15 +780,15 @@ impl Shared<'_> {
 /// The half of the extractor that the workers share.
 ///
 /// Everything here is [`Sync`]. The resolver, the path filter and the progress
-/// callback stay behind on the reader, which is what keeps those three free of
+/// callback stay on the reader, which is what keeps those three free of
 /// any such bound.
 struct ChunkWriter<'s> {
     layout: ExtractLayout,
     existing: ExistingFilePolicy,
     type_filter: Option<&'s [LeagueFileKind]>,
     output_dir: &'s Utf8Path,
-    /* The names the flat layout has handed out, so a second chunk of one name
-    can tell. Behind a mutex because the workers claim names concurrently. */
+    /* The names the flat layout gave so far, so a second chunk of one name can
+    tell. Behind a mutex because the workers claim names concurrently. */
     flat_names: Mutex<HashSet<String>>,
 }
 
@@ -939,7 +939,7 @@ fn write_file(path: &Utf8Path, data: &[u8], policy: ExistingFilePolicy) -> io::R
     }
 }
 
-/// `<hash>.<ext>`, the name a chunk falls back to when its own is refused.
+/// `<hash>.<ext>`, the name a chunk takes when the file system refuses its own.
 fn hashed_name(chunk: &WadChunk, chunk_kind: LeagueFileKind) -> Utf8PathBuf {
     let mut hashed_path = Utf8PathBuf::from(hex_name(chunk.path_hash));
     if let Some(ext) = chunk_kind.extension() {
@@ -951,7 +951,7 @@ fn hashed_name(chunk: &WadChunk, chunk_kind: LeagueFileKind) -> Utf8PathBuf {
 /// Check if a path looks like a hex-encoded hash (e.g., "0123456789abcdef").
 ///
 /// This is the name a chunk gets on disk when nothing resolves its hash, so
-/// a file tree extracted earlier can be told apart into named and unnamed
+/// a caller can sort a file tree extracted earlier into named and unnamed
 /// files.
 ///
 /// # Example
@@ -1648,7 +1648,7 @@ mod tests {
         let mut wad = source.into_wad(chunks);
         let resolver = names(&[(0x1111, "a/same.txt"), (0x2222, "b/same.txt")]);
 
-        // One worker, so the chunks land in the order they are read.
+        // One worker, so the chunks land in the order the reader reads them.
         let report = WadExtractor::new(&resolver)
             .with_layout(ExtractLayout::Flat)
             .with_workers(NonZeroUsize::new(1).unwrap())

--- a/crates/ltk_wad/src/extractor.rs
+++ b/crates/ltk_wad/src/extractor.rs
@@ -5,65 +5,42 @@
 //! # Example
 //!
 //! ```no_run
-//! use std::fs::File;
-//! use std::borrow::Cow;
 //! use std::collections::HashMap;
-//! use ltk_wad::{Wad, PathResolver, WadExtractor, ExtractProgress};
+//! use std::fs::File;
+//! use ltk_wad::{Wad, WadExtractor};
 //!
-//! // Implement your own path resolver (e.g., from a hashtable file)
-//! struct MyHashtable {
-//!     paths: HashMap<u64, String>,
-//! }
+//! let file = File::open("archive.wad.client")?;
+//! let mut wad = Wad::mount(file)?;
 //!
-//! impl PathResolver for MyHashtable {
-//!     fn resolve(&self, path_hash: u64) -> Cow<'_, str> {
-//!         self.paths
-//!             .get(&path_hash)
-//!             .map(|s| Cow::Borrowed(s.as_str()))
-//!             .unwrap_or_else(|| Cow::Owned(format!("{:016x}", path_hash)))
-//!     }
-//! }
+//! // Any `HashMap<u64, String>` is a resolver. Load a hash table into one.
+//! let names: HashMap<u64, String> = HashMap::new();
 //!
-//! fn main() -> Result<(), Box<dyn std::error::Error>> {
-//!     let file = File::open("archive.wad.client")?;
-//!     let mut wad = Wad::mount(file)?;
-//!     let hashtable = MyHashtable { paths: HashMap::new() };
+//! let mut extractor = WadExtractor::new(&names).on_progress(|progress| {
+//!     println!("{:.1}% {}", progress.fraction() * 100.0, progress.path());
+//! });
 //!
-//!     // Build the extractor with a progress callback
-//!     let extractor = WadExtractor::new(&hashtable)
-//!         .on_progress(|progress| {
-//!             println!("Progress: {:.1}% - {}", progress.percent() * 100.0, progress.current_path());
-//!         });
-//!
-//!     let report = extractor.extract_all(&mut wad, "/output/path")?;
-//!     println!("Extracted {} chunks ({} bytes)", report.extracted, report.bytes_written);
-//!
-//!     Ok(())
-//! }
+//! let report = extractor.extract_all(&mut wad, "/output/path")?;
+//! println!("{report}");
+//! # Ok::<(), Box<dyn std::error::Error>>(())
 //! ```
 //!
 //! # Extracting a selection
 //!
-//! [`WadExtractor::extract_chunks`] takes any slice of the archive's chunks, so a
-//! caller that knows which path hashes it wants extracts those alone:
+//! [`WadExtractor::extract_chunks`] takes path hashes, so a caller that knows
+//! which chunks it wants extracts those alone:
 //!
 //! ```no_run
 //! use std::fs::File;
-//! use ltk_wad::{Wad, WadExtractor, HexPathResolver, ExtractLayout, ExistingFilePolicy};
+//! use ltk_wad::{Wad, WadExtractor, NoResolver, ExtractLayout, ExistingFilePolicy};
 //!
 //! let file = File::open("archive.wad.client")?;
 //! let mut wad = Wad::mount(file)?;
 //!
 //! let wanted = [0x1234567890abcdef_u64, 0xfedcba0987654321];
-//! let chunks: Vec<_> = wanted
-//!     .iter()
-//!     .filter_map(|hash| wad.chunks().get(*hash).copied())
-//!     .collect();
-//!
-//! let extractor = WadExtractor::new(&HexPathResolver)
+//! let mut extractor = WadExtractor::new(&NoResolver)
 //!     .with_layout(ExtractLayout::Flat)
 //!     .with_existing_file_policy(ExistingFilePolicy::Skip);
-//! let report = extractor.extract_chunks(&mut wad, &chunks, "/output/path")?;
+//! let report = extractor.extract_chunks(&mut wad, wanted, "/output/path")?;
 //! println!("{} written, {} were there already", report.extracted, report.skipped_existing);
 //! # Ok::<(), Box<dyn std::error::Error>>(())
 //! ```
@@ -71,8 +48,9 @@
 //! # How a chunk is named on disk
 //!
 //! - A path the resolver knows is used as is.
-//! - A path that is a bare hash (16 hex digits) gains the extension its bytes
-//!   identify as, when they identify as anything.
+//! - A chunk the resolver has no name for is written under its hash as sixteen
+//!   hex digits, with the extension its bytes identify as, when they identify
+//!   as anything.
 //! - A path with no extension, or one that collides with an existing directory,
 //!   becomes `<stem>.ltk.<ext>`, or `<stem>.ltk` when the bytes identify as nothing.
 //! - A name the file system refuses as too long falls back to `<hash>.<ext>` in
@@ -90,17 +68,20 @@
 //! writes it. The channel between the two is bounded by the worker count, so
 //! memory holds a few chunks whatever the archive holds. The resolver, the path
 //! filter and the progress callback run on the calling thread only, so none of
-//! them needs to be [`Sync`].
+//! them needs to be [`Sync`]. The progress callback hears of each chunk once
+//! the chunk is done.
 
 use std::{
     borrow::Cow,
     collections::{BTreeMap, HashMap, HashSet},
+    fmt,
     fs::{self, OpenOptions},
+    hash::BuildHasher,
     io::{self, Read, Seek, Write as _},
     num::NonZeroUsize,
     sync::{
         atomic::{AtomicBool, Ordering},
-        mpsc, Mutex, MutexGuard, PoisonError,
+        mpsc, Arc, Mutex, MutexGuard, PoisonError,
     },
     thread,
 };
@@ -110,43 +91,76 @@ use ltk_file::LeagueFileKind;
 
 use crate::{ChunkDecoder, NameRecovery, RecoveredNames, Wad, WadChunk, WadError};
 
-/// A trait for resolving path hashes to human-readable paths.
+/// Names chunks by their path hash.
 ///
-/// Implement this trait to provide path resolution from a hashtable or other source.
+/// A WAD stores the hash of each chunk's path and not the path. A resolver
+/// supplies the path, from a hash table or any other source, and answers
+/// `None` for a hash it has no name for. Such a chunk is written under its
+/// hash as sixteen hex digits.
+///
+/// Every `HashMap<u64, String>` is a resolver, and so is a reference, a `Box`
+/// or an `Arc` of any resolver.
 pub trait PathResolver {
-    /// Resolve a path hash to a path string.
-    ///
-    /// If the hash cannot be resolved, implementations should return the hash
-    /// formatted as a hex string (e.g., `format!("{:016x}", path_hash)`).
-    fn resolve(&self, path_hash: u64) -> Cow<'_, str>;
+    /// The path of `path_hash`, or `None` when the resolver has no name for it.
+    fn resolve(&self, path_hash: u64) -> Option<Cow<'_, str>>;
 
-    /// Whether the resolver names this hash, rather than falling back to the hex string.
+    /// Whether the resolver names `path_hash`.
     ///
-    /// The default reads [`resolve`](Self::resolve) and reports a name that is
-    /// not sixteen hex digits. A resolver that can answer without building the
-    /// string should override it.
+    /// The default calls [`resolve`](Self::resolve). A resolver that can
+    /// answer without building the string should override it.
     fn is_known(&self, path_hash: u64) -> bool {
-        !is_hex_chunk_path(Utf8Path::new(self.resolve(path_hash).as_ref()))
+        self.resolve(path_hash).is_some()
     }
 }
 
-/// A trait for filtering chunks by path pattern.
-///
-/// Implement this trait to provide custom pattern matching logic.
-pub trait PathFilter {
-    /// Returns `true` if the path matches the filter pattern.
-    fn matches(&self, path: &str) -> bool;
+impl<R: PathResolver + ?Sized> PathResolver for &R {
+    fn resolve(&self, path_hash: u64) -> Option<Cow<'_, str>> {
+        (**self).resolve(path_hash)
+    }
+
+    fn is_known(&self, path_hash: u64) -> bool {
+        (**self).is_known(path_hash)
+    }
 }
 
-/// A path resolver that simply returns the hash as a hex string.
-///
-/// Useful when no hashtable is available.
-#[derive(Debug, Clone, Copy, Default)]
-pub struct HexPathResolver;
+impl<R: PathResolver + ?Sized> PathResolver for Box<R> {
+    fn resolve(&self, path_hash: u64) -> Option<Cow<'_, str>> {
+        (**self).resolve(path_hash)
+    }
 
-impl PathResolver for HexPathResolver {
-    fn resolve(&self, path_hash: u64) -> Cow<'_, str> {
-        Cow::Owned(format!("{:016x}", path_hash))
+    fn is_known(&self, path_hash: u64) -> bool {
+        (**self).is_known(path_hash)
+    }
+}
+
+impl<R: PathResolver + ?Sized> PathResolver for Arc<R> {
+    fn resolve(&self, path_hash: u64) -> Option<Cow<'_, str>> {
+        (**self).resolve(path_hash)
+    }
+
+    fn is_known(&self, path_hash: u64) -> bool {
+        (**self).is_known(path_hash)
+    }
+}
+
+impl<S: BuildHasher> PathResolver for HashMap<u64, String, S> {
+    fn resolve(&self, path_hash: u64) -> Option<Cow<'_, str>> {
+        self.get(&path_hash)
+            .map(|path| Cow::Borrowed(path.as_str()))
+    }
+
+    fn is_known(&self, path_hash: u64) -> bool {
+        self.contains_key(&path_hash)
+    }
+}
+
+/// A resolver that names nothing, so every chunk is written under its hash.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct NoResolver;
+
+impl PathResolver for NoResolver {
+    fn resolve(&self, _path_hash: u64) -> Option<Cow<'_, str>> {
+        None
     }
 
     fn is_known(&self, _path_hash: u64) -> bool {
@@ -154,99 +168,82 @@ impl PathResolver for HexPathResolver {
     }
 }
 
-/// A path resolver backed by a `HashMap<u64, String>`.
-#[derive(Debug, Clone, Default)]
-pub struct HashMapPathResolver {
-    paths: HashMap<u64, String>,
+/// A path hash as the sixteen hex digits a nameless chunk is written under.
+pub(crate) fn hex_name(path_hash: u64) -> String {
+    format!("{path_hash:016x}")
 }
 
-impl HashMapPathResolver {
-    /// Create a new resolver with the given path mappings.
-    pub fn new(paths: HashMap<u64, String>) -> Self {
-        Self { paths }
-    }
-
-    /// Insert a path mapping.
-    pub fn insert(&mut self, hash: u64, path: String) {
-        self.paths.insert(hash, path);
-    }
-
-    /// Get a reference to the inner map.
-    pub fn inner(&self) -> &HashMap<u64, String> {
-        &self.paths
-    }
-
-    /// Get a mutable reference to the inner map.
-    pub fn inner_mut(&mut self) -> &mut HashMap<u64, String> {
-        &mut self.paths
-    }
-}
-
-impl PathResolver for HashMapPathResolver {
-    fn resolve(&self, path_hash: u64) -> Cow<'_, str> {
-        self.paths
-            .get(&path_hash)
-            .map(|s| Cow::Borrowed(s.as_str()))
-            .unwrap_or_else(|| Cow::Owned(format!("{:016x}", path_hash)))
-    }
-
-    fn is_known(&self, path_hash: u64) -> bool {
-        self.paths.contains_key(&path_hash)
-    }
-}
-
-impl From<HashMap<u64, String>> for HashMapPathResolver {
-    fn from(paths: HashMap<u64, String>) -> Self {
-        Self::new(paths)
-    }
-}
-
-/// Information about extraction progress.
+/// One chunk done, as [`WadExtractor::on_progress`] reports it.
 #[derive(Debug, Clone)]
 pub struct ExtractProgress<'a> {
-    /// Current chunk index (0-based).
-    pub current: usize,
-    /// Total number of chunks.
-    pub total: usize,
-    /// Path of the current chunk being processed.
-    pub current_path: &'a str,
-    /// Path hash of the current chunk.
-    pub path_hash: u64,
+    done: usize,
+    total: usize,
+    path_hash: u64,
+    path: &'a str,
+    result: ExtractResult,
+    bytes: u64,
 }
 
 impl ExtractProgress<'_> {
-    /// Progress as a fraction from 0.0 to 1.0.
-    #[inline]
-    pub fn percent(&self) -> f64 {
+    /// Chunks done so far, this one included.
+    pub fn done(&self) -> usize {
+        self.done
+    }
+
+    /// Chunks the extraction set out to do.
+    pub fn total(&self) -> usize {
+        self.total
+    }
+
+    /// [`done`](Self::done) over [`total`](Self::total), from 0.0 to 1.0.
+    ///
+    /// Zero when there was nothing to do.
+    pub fn fraction(&self) -> f64 {
         if self.total == 0 {
             0.0
         } else {
-            self.current as f64 / self.total as f64
+            self.done as f64 / self.total as f64
         }
     }
 
-    /// Get the current path being processed.
-    #[inline]
-    pub fn current_path(&self) -> &str {
-        self.current_path
+    /// The chunk's path hash.
+    pub fn path_hash(&self) -> u64 {
+        self.path_hash
+    }
+
+    /// The chunk's path, or its hash as sixteen hex digits when nothing named it.
+    pub fn path(&self) -> &str {
+        self.path
+    }
+
+    /// What became of the chunk.
+    pub fn result(&self) -> ExtractResult {
+        self.result
+    }
+
+    /// Bytes written for the chunk. Zero unless it was extracted.
+    pub fn bytes(&self) -> u64 {
+        self.bytes
     }
 }
 
-/// Result of a single chunk extraction.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// What became of one chunk.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
 pub enum ExtractResult {
-    /// The chunk was extracted successfully.
+    /// Written to disk.
     Extracted,
-    /// The chunk was skipped due to type filtering.
+    /// Left out by the type filter.
     SkippedByType,
-    /// The chunk was skipped due to pattern filtering.
-    SkippedByPattern,
-    /// The chunk's file existed already, and the policy was [`ExistingFilePolicy::Skip`].
+    /// Left out by the path filter.
+    SkippedByPath,
+    /// Its file existed already, and the policy was [`ExistingFilePolicy::Skip`].
     SkippedExisting,
 }
 
 /// Where each extracted chunk lands under the output directory.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[non_exhaustive]
 pub enum ExtractLayout {
     /// At its resolved path, with every directory of that path.
     #[default]
@@ -255,13 +252,13 @@ pub enum ExtractLayout {
     ///
     /// When two chunks of one extraction share a name, the second keeps apart
     /// with its path hash before the extension, as `name.<hash>.ext`. Which of
-    /// the two is second follows write order, so build one extractor per
-    /// extraction when driving [`WadExtractor::extract_chunk_data`] yourself.
+    /// the two is second follows write order.
     Flat,
 }
 
 /// What to do with a chunk whose file exists already.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[non_exhaustive]
 pub enum ExistingFilePolicy {
     /// Write over it.
     #[default]
@@ -283,15 +280,18 @@ pub struct ExtractReport {
     pub skipped_existing: usize,
     /// Chunks the path filter or the type filter left out.
     pub skipped_by_filter: usize,
+    /// Path hashes given to [`extract_chunks`](WadExtractor::extract_chunks)
+    /// that the archive holds no chunk for.
+    pub missing: Vec<u64>,
     /// Bytes written, after decompression.
     pub bytes_written: u64,
     /// Written chunks, by the kind their bytes identify as.
     pub by_kind: BTreeMap<LeagueFileKind, usize>,
     /// The cancel flag was set, so some chunks were never read.
     pub cancelled: bool,
-    /// Names that [`with_name_recovery`](WadExtractor::with_name_recovery) read
-    /// out of the archive's bins, by path hash. Empty when recovery was off.
-    pub recovered_names: HashMap<u64, String>,
+    /// What [`with_name_recovery`](WadExtractor::with_name_recovery) read out
+    /// of the archive's bins. Empty when recovery was off.
+    pub recovered: RecoveredNames,
 }
 
 impl ExtractReport {
@@ -302,9 +302,37 @@ impl ExtractReport {
                 self.bytes_written += bytes;
                 *self.by_kind.entry(kind).or_insert(0) += 1;
             }
-            ChunkOutcome::SkippedByType => self.skipped_by_filter += 1,
+            ChunkOutcome::SkippedByType | ChunkOutcome::SkippedByPath => {
+                self.skipped_by_filter += 1
+            }
             ChunkOutcome::SkippedExisting => self.skipped_existing += 1,
         }
+    }
+}
+
+impl fmt::Display for ExtractReport {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{} extracted, {} bytes",
+            self.extracted, self.bytes_written
+        )?;
+        if self.skipped_existing > 0 {
+            write!(f, ", {} existed", self.skipped_existing)?;
+        }
+        if self.skipped_by_filter > 0 {
+            write!(f, ", {} filtered out", self.skipped_by_filter)?;
+        }
+        if !self.missing.is_empty() {
+            write!(f, ", {} missing", self.missing.len())?;
+        }
+        if !self.recovered.is_empty() {
+            write!(f, ", {} names recovered", self.recovered.len())?;
+        }
+        if self.cancelled {
+            f.write_str(", cancelled")?;
+        }
+        Ok(())
     }
 }
 
@@ -313,7 +341,17 @@ impl ExtractReport {
 enum ChunkOutcome {
     Written { kind: LeagueFileKind, bytes: u64 },
     SkippedByType,
+    SkippedByPath,
     SkippedExisting,
+}
+
+impl ChunkOutcome {
+    fn bytes(self) -> u64 {
+        match self {
+            Self::Written { bytes, .. } => bytes,
+            Self::SkippedByType | Self::SkippedByPath | Self::SkippedExisting => 0,
+        }
+    }
 }
 
 impl From<ChunkOutcome> for ExtractResult {
@@ -321,100 +359,88 @@ impl From<ChunkOutcome> for ExtractResult {
         match outcome {
             ChunkOutcome::Written { .. } => ExtractResult::Extracted,
             ChunkOutcome::SkippedByType => ExtractResult::SkippedByType,
+            ChunkOutcome::SkippedByPath => ExtractResult::SkippedByPath,
             ChunkOutcome::SkippedExisting => ExtractResult::SkippedExisting,
         }
     }
 }
-
-/// Type alias for the progress callback function.
-pub type ProgressCallback<'a> = Box<dyn Fn(ExtractProgress<'_>) + 'a>;
 
 /// Most workers an extraction starts unless [`WadExtractor::with_workers`] says
 /// otherwise. Each worker holds a compressed and a decompressed chunk at once,
 /// and a wide machine would otherwise hold dozens of the largest ones.
 const DEFAULT_WORKER_CAP: usize = 8;
 
+type PathFilter<'a> = Box<dyn Fn(&str) -> bool + 'a>;
+type ProgressCallback<'a> = Box<dyn FnMut(&ExtractProgress<'_>) + 'a>;
+
 /// Configuration and execution of WAD chunk extraction.
 ///
-/// # Type Parameters
-///
-/// * `R` - The path resolver type
-/// * `F` - The path filter type (optional)
-pub struct WadExtractor<'a, R: PathResolver, F: PathFilter = NoFilter> {
-    resolver: &'a R,
-    filter: Option<F>,
+/// Build one with [`new`](Self::new), set it up with the `with_*` methods, and
+/// run it with [`extract_all`](Self::extract_all) or
+/// [`extract_chunks`](Self::extract_chunks). One extractor runs any number of
+/// extractions.
+pub struct WadExtractor<'a> {
+    resolver: &'a dyn PathResolver,
+    filter: Option<PathFilter<'a>>,
     type_filter: Option<Vec<LeagueFileKind>>,
-    progress_callback: Option<ProgressCallback<'a>>,
+    progress: Option<ProgressCallback<'a>>,
     layout: ExtractLayout,
     existing: ExistingFilePolicy,
     cancel: Option<&'a AtomicBool>,
     workers: Option<NonZeroUsize>,
     recover_names: bool,
-    /* The names the flat layout has handed out, so a second chunk of one name
-    can tell. Behind a mutex because the workers claim names concurrently. */
-    flat_names: Mutex<HashSet<String>>,
 }
 
-/// A filter that matches all paths (no filtering).
-#[derive(Debug, Clone, Copy, Default)]
-pub struct NoFilter;
-
-impl PathFilter for NoFilter {
-    fn matches(&self, _path: &str) -> bool {
-        true
+impl fmt::Debug for WadExtractor<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("WadExtractor")
+            .field("layout", &self.layout)
+            .field("existing", &self.existing)
+            .field("type_filter", &self.type_filter)
+            .field("has_filter", &self.filter.is_some())
+            .field("has_progress", &self.progress.is_some())
+            .field("workers", &self.workers)
+            .field("recover_names", &self.recover_names)
+            .finish_non_exhaustive()
     }
 }
 
-impl<'a, R: PathResolver> WadExtractor<'a, R, NoFilter> {
-    /// Create a new extractor with the given path resolver.
-    pub fn new(resolver: &'a R) -> Self {
+impl<'a> WadExtractor<'a> {
+    /// An extractor that names chunks through `resolver`.
+    pub fn new(resolver: &'a dyn PathResolver) -> Self {
         Self {
             resolver,
             filter: None,
             type_filter: None,
-            progress_callback: None,
+            progress: None,
             layout: ExtractLayout::default(),
             existing: ExistingFilePolicy::default(),
             cancel: None,
             workers: None,
             recover_names: false,
-            flat_names: Mutex::default(),
-        }
-    }
-}
-
-impl<'a, R: PathResolver, F: PathFilter> WadExtractor<'a, R, F> {
-    /// Set a path filter for the extractor.
-    ///
-    /// Only chunks whose paths match the filter will be extracted.
-    pub fn with_filter<F2: PathFilter>(self, filter: F2) -> WadExtractor<'a, R, F2> {
-        WadExtractor {
-            resolver: self.resolver,
-            filter: Some(filter),
-            type_filter: self.type_filter,
-            progress_callback: self.progress_callback,
-            layout: self.layout,
-            existing: self.existing,
-            cancel: self.cancel,
-            workers: self.workers,
-            recover_names: self.recover_names,
-            flat_names: self.flat_names,
         }
     }
 
-    /// Set a type filter for the extractor.
+    /// Extract only the chunks whose path `filter` accepts.
     ///
-    /// Only chunks whose detected file type is in the list will be extracted.
-    pub fn with_type_filter(mut self, types: Vec<LeagueFileKind>) -> Self {
-        self.type_filter = Some(types);
+    /// The filter sees the path the resolver gave, or the hash as sixteen hex
+    /// digits when it gave none. It runs on the calling thread.
+    pub fn with_filter(mut self, filter: impl Fn(&str) -> bool + 'a) -> Self {
+        self.filter = Some(Box::new(filter));
         self
     }
 
-    /// Set a progress callback.
+    /// Extract only the chunks whose bytes identify as one of `kinds`.
+    pub fn with_type_filter(mut self, kinds: impl IntoIterator<Item = LeagueFileKind>) -> Self {
+        self.type_filter = Some(kinds.into_iter().collect());
+        self
+    }
+
+    /// Hear of each chunk once it is done, skipped chunks included.
     ///
-    /// The callback will be invoked for each chunk processed (including skipped chunks).
-    pub fn on_progress<C: Fn(ExtractProgress<'_>) + 'a>(mut self, callback: C) -> Self {
-        self.progress_callback = Some(Box::new(callback));
+    /// The callback runs on the calling thread.
+    pub fn on_progress(mut self, callback: impl FnMut(&ExtractProgress<'_>) + 'a) -> Self {
+        self.progress = Some(Box::new(callback));
         self
     }
 
@@ -456,8 +482,8 @@ impl<'a, R: PathResolver, F: PathFilter> WadExtractor<'a, R, F> {
     /// cannot name, before anything is written.
     ///
     /// Read [`NameRecovery`] for what it costs and what it finds. The names
-    /// land in [`ExtractReport::recovered_names`], and the extraction uses the
-    /// same workers and cancel flag for the read.
+    /// land in [`ExtractReport::recovered`], and the extraction uses the same
+    /// workers and cancel flag for the read.
     pub fn with_name_recovery(mut self) -> Self {
         self.recover_names = true;
         self
@@ -467,33 +493,57 @@ impl<'a, R: PathResolver, F: PathFilter> WadExtractor<'a, R, F> {
     ///
     /// # Errors
     ///
-    /// Fails on the first chunk that cannot be read, decompressed or written.
-    /// Chunks written before it stay on disk.
-    pub fn extract_all<TSource: Read + Seek>(
-        &self,
-        wad: &mut Wad<TSource>,
+    /// Fails on the first chunk that cannot be read, decompressed or written,
+    /// with a [`WadError::Chunk`] that names it. Chunks written before it stay
+    /// on disk.
+    pub fn extract_all<S: Read + Seek>(
+        &mut self,
+        wad: &mut Wad<S>,
         output_dir: impl AsRef<Utf8Path>,
     ) -> Result<ExtractReport, WadError> {
         let chunks: Vec<WadChunk> = wad.chunks().iter().copied().collect();
-        self.extract_chunks(wad, &chunks, output_dir)
+        self.run(wad, chunks, Vec::new(), output_dir.as_ref())
     }
 
-    /// Extract `chunks` of `wad` into `output_dir`, in the order given.
+    /// Extract the chunks of `wad` with the given path hashes into
+    /// `output_dir`, in the order given.
     ///
-    /// A chunk is read at the offsets it carries, so take the chunks from
-    /// [`Wad::chunks`] of the same archive.
+    /// A hash given twice is extracted once. A hash the archive holds no chunk
+    /// for is listed under [`ExtractReport::missing`] and is not an error.
     ///
     /// # Errors
     ///
-    /// Fails on the first chunk that cannot be read, decompressed or written.
-    /// Chunks written before it stay on disk.
-    pub fn extract_chunks<TSource: Read + Seek>(
-        &self,
-        wad: &mut Wad<TSource>,
-        chunks: &[WadChunk],
+    /// Fails on the first chunk that cannot be read, decompressed or written,
+    /// with a [`WadError::Chunk`] that names it. Chunks written before it stay
+    /// on disk.
+    pub fn extract_chunks<S: Read + Seek>(
+        &mut self,
+        wad: &mut Wad<S>,
+        path_hashes: impl IntoIterator<Item = u64>,
         output_dir: impl AsRef<Utf8Path>,
     ) -> Result<ExtractReport, WadError> {
-        let output_dir = output_dir.as_ref();
+        let mut seen = HashSet::new();
+        let mut chunks = Vec::new();
+        let mut missing = Vec::new();
+        for path_hash in path_hashes {
+            if !seen.insert(path_hash) {
+                continue;
+            }
+            match wad.chunks().get(path_hash) {
+                Some(chunk) => chunks.push(*chunk),
+                None => missing.push(path_hash),
+            }
+        }
+        self.run(wad, chunks, missing, output_dir.as_ref())
+    }
+
+    fn run<S: Read + Seek>(
+        &mut self,
+        wad: &mut Wad<S>,
+        chunks: Vec<WadChunk>,
+        missing: Vec<u64>,
+        output_dir: &Utf8Path,
+    ) -> Result<ExtractReport, WadError> {
         let workers = self.workers.map_or_else(default_workers, NonZeroUsize::get);
 
         let recovered = if self.recover_names {
@@ -508,22 +558,49 @@ impl<'a, R: PathResolver, F: PathFilter> WadExtractor<'a, R, F> {
         let resolver = recovered.over(self.resolver);
 
         let shared = Shared {
-            writer: self.writer(output_dir),
+            writer: ChunkWriter {
+                layout: self.layout,
+                existing: self.existing,
+                type_filter: self.type_filter.as_deref(),
+                output_dir,
+                flat_names: Mutex::default(),
+            },
             report: Mutex::default(),
             failure: Mutex::default(),
         };
         let (sender, receiver) = mpsc::sync_channel::<Job>(workers);
         let receiver = Mutex::new(receiver);
+        let (done_sender, done) = mpsc::channel::<Done>();
 
-        /* Taken inside the scope so it drops before the workers are joined.
-        A worker only stops once every sender is gone. */
-        let mut sender = Some(sender);
+        let mut reader = Reader {
+            filter: self.filter.as_deref(),
+            cancel: self.cancel,
+            progress: Progress {
+                callback: self.progress.as_deref_mut(),
+                done: 0,
+                total: chunks.len(),
+            },
+        };
+
         let cancelled = thread::scope(|scope| {
+            let shared = &shared;
+            let receiver = &receiver;
             for _ in 0..workers {
-                scope.spawn(|| shared.run_worker(&receiver));
+                let done_sender = done_sender.clone();
+                scope.spawn(move || shared.run_worker(receiver, &done_sender));
             }
-            let sender = sender.take().expect("the sender is taken once");
-            self.read_chunks(wad, chunks, &sender, &shared, &resolver)
+            /* The workers hold the clones. The drain below ends once every
+            sender is gone, and this one would never go on its own. */
+            drop(done_sender);
+
+            let result = reader.read_chunks(wad, &chunks, &resolver, &sender, shared, &done);
+            /* A worker exits, and lets go of its done sender, only once every
+            job sender is gone. */
+            drop(sender);
+            for finished in done.iter() {
+                reader.progress.report(&finished);
+            }
+            result
         })?;
 
         if let Some(error) = shared
@@ -538,85 +615,9 @@ impl<'a, R: PathResolver, F: PathFilter> WadExtractor<'a, R, F> {
             .into_inner()
             .unwrap_or_else(PoisonError::into_inner);
         report.cancelled = cancelled;
-        report.recovered_names = recovered.names;
+        report.missing = missing;
+        report.recovered = recovered;
         Ok(report)
-    }
-
-    /// Extract a single chunk from already-decompressed data to the specified directory.
-    ///
-    /// This is useful for parallel workflows where decompression is done separately
-    /// (e.g. via [`decompress_raw`](crate::decompress_raw)). The layout and the
-    /// existing-file policy apply as they do to [`extract_chunks`](Self::extract_chunks).
-    pub fn extract_chunk_data(
-        &self,
-        chunk: &WadChunk,
-        chunk_data: &[u8],
-        chunk_path: &Utf8Path,
-        output_dir: &Utf8Path,
-    ) -> Result<ExtractResult, WadError> {
-        self.writer(output_dir)
-            .write_chunk(chunk, chunk_data, chunk_path)
-            .map(ExtractResult::from)
-    }
-
-    fn writer<'s>(&'s self, output_dir: &'s Utf8Path) -> ChunkWriter<'s> {
-        ChunkWriter {
-            layout: self.layout,
-            existing: self.existing,
-            type_filter: self.type_filter.as_deref(),
-            output_dir,
-            flat_names: &self.flat_names,
-        }
-    }
-
-    /// Feed the workers, chunk by chunk, and say whether the cancel flag stopped it.
-    fn read_chunks<TSource: Read + Seek>(
-        &self,
-        wad: &mut Wad<TSource>,
-        chunks: &[WadChunk],
-        sender: &mpsc::SyncSender<Job>,
-        shared: &Shared<'_>,
-        resolver: &impl PathResolver,
-    ) -> Result<bool, WadError> {
-        let total = chunks.len();
-        for (index, chunk) in chunks.iter().enumerate() {
-            if self.cancel.is_some_and(|flag| flag.load(Ordering::Relaxed)) {
-                return Ok(true);
-            }
-            if shared.failed() {
-                return Ok(false);
-            }
-
-            let chunk_path = resolver.resolve(chunk.path_hash);
-
-            if let Some(callback) = &self.progress_callback {
-                callback(ExtractProgress {
-                    current: index,
-                    total,
-                    current_path: chunk_path.as_ref(),
-                    path_hash: chunk.path_hash,
-                });
-            }
-
-            if let Some(filter) = &self.filter {
-                if !filter.matches(chunk_path.as_ref()) {
-                    lock(&shared.report).skipped_by_filter += 1;
-                    continue;
-                }
-            }
-
-            let raw = wad.load_chunk_raw(chunk)?;
-            let job = Job {
-                chunk: *chunk,
-                path: chunk_path.into_owned(),
-                raw,
-            };
-            /* Refused only once every worker is gone, which takes a panic. */
-            if sender.send(job).is_err() {
-                break;
-            }
-        }
-        Ok(false)
     }
 }
 
@@ -632,7 +633,101 @@ pub(crate) fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
 struct Job {
     chunk: WadChunk,
     path: String,
+    named: bool,
     raw: Box<[u8]>,
+}
+
+/// One chunk on its way back from a worker, for the progress callback.
+struct Done {
+    path_hash: u64,
+    path: String,
+    outcome: ChunkOutcome,
+}
+
+/// The progress callback and its count. Both stay on the reader thread.
+struct Progress<'c, 'a> {
+    callback: Option<&'c mut (dyn FnMut(&ExtractProgress<'_>) + 'a)>,
+    done: usize,
+    total: usize,
+}
+
+impl Progress<'_, '_> {
+    fn report(&mut self, finished: &Done) {
+        self.done += 1;
+        if let Some(callback) = &mut self.callback {
+            callback(&ExtractProgress {
+                done: self.done,
+                total: self.total,
+                path_hash: finished.path_hash,
+                path: &finished.path,
+                result: finished.outcome.into(),
+                bytes: finished.outcome.bytes(),
+            });
+        }
+    }
+}
+
+/// The half of the extractor that runs on the calling thread.
+struct Reader<'r, 'a> {
+    filter: Option<&'r (dyn Fn(&str) -> bool + 'a)>,
+    cancel: Option<&'r AtomicBool>,
+    progress: Progress<'r, 'a>,
+}
+
+impl Reader<'_, '_> {
+    /// Feed the workers, chunk by chunk, and say whether the cancel flag stopped it.
+    fn read_chunks<S: Read + Seek>(
+        &mut self,
+        wad: &mut Wad<S>,
+        chunks: &[WadChunk],
+        resolver: &dyn PathResolver,
+        sender: &mpsc::SyncSender<Job>,
+        shared: &Shared<'_>,
+        done: &mpsc::Receiver<Done>,
+    ) -> Result<bool, WadError> {
+        for chunk in chunks {
+            if self.cancel.is_some_and(|flag| flag.load(Ordering::Relaxed)) {
+                return Ok(true);
+            }
+            if shared.failed() {
+                return Ok(false);
+            }
+
+            let (path, named) = match resolver.resolve(chunk.path_hash) {
+                Some(path) => (path.into_owned(), true),
+                None => (hex_name(chunk.path_hash), false),
+            };
+
+            if self.filter.is_some_and(|filter| !filter(path.as_str())) {
+                let finished = Done {
+                    path_hash: chunk.path_hash,
+                    path,
+                    outcome: ChunkOutcome::SkippedByPath,
+                };
+                lock(&shared.report).record(finished.outcome);
+                self.progress.report(&finished);
+                continue;
+            }
+
+            let raw = wad
+                .load_chunk_raw(chunk)
+                .map_err(|error| WadError::chunk(chunk.path_hash, &path, error))?;
+            let job = Job {
+                chunk: *chunk,
+                path,
+                named,
+                raw,
+            };
+            /* Refused only once every worker is gone, which takes a panic. */
+            if sender.send(job).is_err() {
+                break;
+            }
+            for finished in done.try_iter() {
+                self.progress.report(&finished);
+            }
+        }
+        Ok(false)
+    }
 }
 
 /// What the workers share: the writer, the tally, and the first failure.
@@ -651,7 +746,7 @@ impl Shared<'_> {
     ///
     /// After a failure the jobs are drained and dropped rather than written,
     /// so a reader blocked on a full channel gets to see the failure too.
-    fn run_worker(&self, receiver: &Mutex<mpsc::Receiver<Job>>) {
+    fn run_worker(&self, receiver: &Mutex<mpsc::Receiver<Job>>, done: &mpsc::Sender<Done>) {
         let mut decoder = ChunkDecoder::new();
         loop {
             let Ok(job) = lock(receiver).recv() else {
@@ -661,11 +756,19 @@ impl Shared<'_> {
                 continue;
             }
             match self.writer.write(&job, &mut decoder) {
-                Ok(outcome) => lock(&self.report).record(outcome),
+                Ok(outcome) => {
+                    lock(&self.report).record(outcome);
+                    /* The receiver outlives every worker, so this cannot fail. */
+                    let _ = done.send(Done {
+                        path_hash: job.chunk.path_hash,
+                        path: job.path,
+                        outcome,
+                    });
+                }
                 Err(error) => {
                     let mut failure = lock(&self.failure);
                     if failure.is_none() {
-                        *failure = Some(error);
+                        *failure = Some(WadError::chunk(job.chunk.path_hash, &job.path, error));
                     }
                 }
             }
@@ -683,7 +786,9 @@ struct ChunkWriter<'s> {
     existing: ExistingFilePolicy,
     type_filter: Option<&'s [LeagueFileKind]>,
     output_dir: &'s Utf8Path,
-    flat_names: &'s Mutex<HashSet<String>>,
+    /* The names the flat layout has handed out, so a second chunk of one name
+    can tell. Behind a mutex because the workers claim names concurrently. */
+    flat_names: Mutex<HashSet<String>>,
 }
 
 impl ChunkWriter<'_> {
@@ -693,7 +798,7 @@ impl ChunkWriter<'_> {
             job.chunk.compression_type,
             job.chunk.uncompressed_size,
         )?;
-        self.write_chunk(&job.chunk, &data, Utf8Path::new(&job.path))
+        self.write_chunk(&job.chunk, &data, Utf8Path::new(&job.path), job.named)
     }
 
     fn write_chunk(
@@ -701,6 +806,7 @@ impl ChunkWriter<'_> {
         chunk: &WadChunk,
         chunk_data: &[u8],
         chunk_path: &Utf8Path,
+        named: bool,
     ) -> Result<ChunkOutcome, WadError> {
         let chunk_kind = LeagueFileKind::identify_from_bytes(chunk_data);
 
@@ -712,9 +818,11 @@ impl ChunkWriter<'_> {
         }
 
         let relative_path = match self.layout {
-            ExtractLayout::Paths => self.resolve_final_path(chunk_path, chunk_data, chunk_kind),
+            ExtractLayout::Paths => {
+                self.resolve_final_path(chunk_path, named, chunk_data, chunk_kind)
+            }
             ExtractLayout::Flat => {
-                self.resolve_flat_path(chunk, chunk_path, chunk_data, chunk_kind)
+                self.resolve_flat_path(chunk, chunk_path, named, chunk_data, chunk_kind)
             }
         };
         let full_path = self.output_dir.join(&relative_path);
@@ -745,13 +853,13 @@ impl ChunkWriter<'_> {
     fn resolve_final_path(
         &self,
         chunk_path: &Utf8Path,
+        named: bool,
         chunk_data: &[u8],
         chunk_kind: LeagueFileKind,
     ) -> Utf8PathBuf {
         let mut final_path = chunk_path.to_path_buf();
 
-        // If the path looks like a hex hash (no extension), add the detected extension
-        if is_hex_chunk_path(&final_path) {
+        if !named {
             if let Some(ext) = chunk_kind.extension() {
                 final_path.set_extension(ext);
             }
@@ -777,24 +885,25 @@ impl ChunkWriter<'_> {
         &self,
         chunk: &WadChunk,
         chunk_path: &Utf8Path,
+        named: bool,
         chunk_data: &[u8],
         chunk_kind: LeagueFileKind,
     ) -> Utf8PathBuf {
         let file_name = Utf8Path::new(chunk_path.file_name().unwrap_or_default());
-        let named = self.resolve_final_path(file_name, chunk_data, chunk_kind);
+        let resolved = self.resolve_final_path(file_name, named, chunk_data, chunk_kind);
 
-        let mut names = lock(self.flat_names);
-        if names.insert(named.as_str().to_owned()) {
-            return named;
+        let mut names = lock(&self.flat_names);
+        if names.insert(resolved.as_str().to_owned()) {
+            return resolved;
         }
 
-        let suffixed = match named.extension() {
+        let suffixed = match resolved.extension() {
             Some(ext) => format!(
                 "{}.{:016x}.{ext}",
-                named.file_stem().unwrap_or_default(),
+                resolved.file_stem().unwrap_or_default(),
                 chunk.path_hash
             ),
-            None => format!("{}.{:016x}", named.as_str(), chunk.path_hash),
+            None => format!("{}.{:016x}", resolved.as_str(), chunk.path_hash),
         };
         names.insert(suffixed.clone());
         Utf8PathBuf::from(suffixed)
@@ -831,7 +940,7 @@ fn write_file(path: &Utf8Path, data: &[u8], policy: ExistingFilePolicy) -> io::R
 
 /// `<hash>.<ext>`, the name a chunk falls back to when its own is refused.
 fn hashed_name(chunk: &WadChunk, chunk_kind: LeagueFileKind) -> Utf8PathBuf {
-    let mut hashed_path = Utf8PathBuf::from(format!("{:016x}", chunk.path_hash));
+    let mut hashed_path = Utf8PathBuf::from(hex_name(chunk.path_hash));
     if let Some(ext) = chunk_kind.extension() {
         hashed_path.set_extension(ext);
     }
@@ -840,8 +949,9 @@ fn hashed_name(chunk: &WadChunk, chunk_kind: LeagueFileKind) -> Utf8PathBuf {
 
 /// Check if a path looks like a hex-encoded hash (e.g., "0123456789abcdef").
 ///
-/// This is useful for determining if a chunk path is unresolved (just a hash)
-/// or if it has been resolved to a human-readable path.
+/// This is the name a chunk gets on disk when nothing resolves its hash, so
+/// a file tree extracted earlier can be told apart into named and unnamed
+/// files.
 ///
 /// # Example
 ///
@@ -866,42 +976,6 @@ fn build_ltk_name(file_stem: impl AsRef<str>, chunk_data: &[u8]) -> String {
         None => format!("{}.ltk", file_stem.as_ref()),
     }
 }
-
-#[cfg(feature = "regex")]
-mod regex_filter {
-    use super::PathFilter;
-
-    /// A path filter using a regular expression.
-    #[derive(Debug, Clone)]
-    pub struct RegexFilter {
-        pattern: regex::Regex,
-    }
-
-    impl RegexFilter {
-        /// Create a new regex filter from a pattern string.
-        ///
-        /// Returns `None` if the pattern is invalid.
-        pub fn new(pattern: &str) -> Option<Self> {
-            regex::Regex::new(pattern)
-                .ok()
-                .map(|pattern| Self { pattern })
-        }
-
-        /// Create a new regex filter from a compiled regex.
-        pub fn from_regex(pattern: regex::Regex) -> Self {
-            Self { pattern }
-        }
-    }
-
-    impl PathFilter for RegexFilter {
-        fn matches(&self, path: &str) -> bool {
-            self.pattern.is_match(path)
-        }
-    }
-}
-
-#[cfg(feature = "regex")]
-pub use regex_filter::RegexFilter;
 
 #[cfg(test)]
 mod tests {
@@ -956,6 +1030,7 @@ mod tests {
                 checksum: 0u64,
                 signature: [0u8; 256],
                 source: self,
+                decoder: ChunkDecoder::new(),
             }
         }
     }
@@ -1024,23 +1099,24 @@ mod tests {
         }
     }
 
-    /// Custom path filter for testing.
-    struct PrefixFilter {
-        prefix: String,
+    /// A resolver over the given names.
+    fn names(entries: &[(u64, &str)]) -> HashMap<u64, String> {
+        entries
+            .iter()
+            .map(|(hash, path)| (*hash, (*path).to_owned()))
+            .collect()
     }
 
-    impl PrefixFilter {
-        fn new(prefix: impl Into<String>) -> Self {
-            Self {
-                prefix: prefix.into(),
-            }
-        }
-    }
-
-    impl PathFilter for PrefixFilter {
-        fn matches(&self, path: &str) -> bool {
-            path.starts_with(&self.prefix)
-        }
+    /// A wad of one uncompressed chunk at `path_hash`, with its resolver.
+    fn one_chunk_wad(
+        path_hash: u64,
+        path: &str,
+        data: &[u8],
+    ) -> (Wad<MockWadSource>, HashMap<u64, String>) {
+        let mut source = MockWadSource::new();
+        let offset = source.write_at(1000, data);
+        let chunks = WadChunks::from_iter([create_uncompressed_chunk(path_hash, offset, data)]);
+        (source.into_wad(chunks), names(&[(path_hash, path)]))
     }
 
     // =============================================================================
@@ -1085,93 +1161,34 @@ mod tests {
     // =============================================================================
 
     #[test]
-    fn test_hex_path_resolver() {
-        let resolver = HexPathResolver;
-        assert_eq!(resolver.resolve(0x0123456789abcdef), "0123456789abcdef");
+    fn no_resolver_names_nothing() {
+        assert_eq!(NoResolver.resolve(0x0123456789abcdef), None);
+        assert!(!NoResolver.is_known(0x0123456789abcdef));
     }
 
     #[test]
-    fn test_hex_path_resolver_formats_hash_correctly() {
-        let resolver = HexPathResolver;
+    fn a_hash_map_is_a_resolver() {
+        let resolver = names(&[(0x1234, "assets/test.bin")]);
 
-        // Test various hashes
-        assert_eq!(resolver.resolve(0x0), "0000000000000000");
-        assert_eq!(resolver.resolve(0x1), "0000000000000001");
-        assert_eq!(resolver.resolve(0x123456789abcdef0), "123456789abcdef0");
-        assert_eq!(resolver.resolve(u64::MAX), "ffffffffffffffff");
+        assert_eq!(resolver.resolve(0x1234).as_deref(), Some("assets/test.bin"));
+        assert_eq!(resolver.resolve(0x5678), None);
+        assert!(resolver.is_known(0x1234));
+        assert!(!resolver.is_known(0x5678));
     }
 
     #[test]
-    fn test_hashmap_path_resolver() {
-        let mut resolver = HashMapPathResolver::new(HashMap::new());
-        resolver.insert(0x1234, "assets/test.bin".to_string());
+    fn references_boxes_and_arcs_of_a_resolver_are_resolvers() {
+        let map = names(&[(0x1, "one")]);
+        let by_ref = &map;
+        let boxed: Box<dyn PathResolver> = Box::new(map.clone());
+        let shared: Arc<dyn PathResolver> = Arc::new(map.clone());
 
-        assert_eq!(resolver.resolve(0x1234), "assets/test.bin");
-        assert_eq!(resolver.resolve(0x5678), "0000000000005678");
-    }
-
-    #[test]
-    fn test_hashmap_path_resolver_resolves_known_paths() {
-        let mut resolver = HashMapPathResolver::default();
-        resolver.insert(0x1234, "assets/champions/aatrox.bin".to_string());
-        resolver.insert(0x5678, "data/maps/summoners_rift.mapgeo".to_string());
-
-        assert_eq!(resolver.resolve(0x1234), "assets/champions/aatrox.bin");
-        assert_eq!(resolver.resolve(0x5678), "data/maps/summoners_rift.mapgeo");
-    }
-
-    #[test]
-    fn test_hashmap_path_resolver_falls_back_to_hex() {
-        let resolver = HashMapPathResolver::new(HashMap::new());
-
-        // Unknown hashes should return hex format
-        assert_eq!(resolver.resolve(0xdeadbeef), "00000000deadbeef");
-        assert_eq!(resolver.resolve(0x1234567890abcdef), "1234567890abcdef");
-    }
-
-    #[test]
-    fn test_hashmap_path_resolver_from_hashmap() {
-        let mut paths = HashMap::new();
-        paths.insert(0xabc, "test/path.bin".to_string());
-
-        let resolver: HashMapPathResolver = paths.into();
-        assert_eq!(resolver.resolve(0xabc), "test/path.bin");
-    }
-
-    #[test]
-    fn test_hashmap_path_resolver_inner_access() {
-        let mut resolver = HashMapPathResolver::default();
-        resolver.insert(0x1, "one".to_string());
-
-        // Test inner() access
-        assert_eq!(resolver.inner().get(&0x1), Some(&"one".to_string()));
-
-        // Test inner_mut() access
-        resolver.inner_mut().insert(0x2, "two".to_string());
-        assert_eq!(resolver.resolve(0x2), "two");
-    }
-
-    // =============================================================================
-    // PathFilter Tests
-    // =============================================================================
-
-    #[test]
-    fn test_no_filter_matches_everything() {
-        let filter = NoFilter;
-
-        assert!(filter.matches(""));
-        assert!(filter.matches("any/path/here.bin"));
-        assert!(filter.matches("0123456789abcdef"));
-    }
-
-    #[test]
-    fn test_custom_prefix_filter() {
-        let filter = PrefixFilter::new("assets/");
-
-        assert!(filter.matches("assets/champions/aatrox.bin"));
-        assert!(filter.matches("assets/maps/test.mapgeo"));
-        assert!(!filter.matches("data/test.bin"));
-        assert!(!filter.matches(""));
+        let resolvers: [&dyn PathResolver; 3] = [&by_ref, &boxed, &shared];
+        for resolver in resolvers {
+            assert_eq!(resolver.resolve(0x1).as_deref(), Some("one"));
+            assert!(resolver.is_known(0x1));
+            assert!(!resolver.is_known(0x2));
+        }
     }
 
     // =============================================================================
@@ -1203,51 +1220,35 @@ mod tests {
     // ExtractProgress Tests
     // =============================================================================
 
-    #[test]
-    fn test_extract_progress() {
-        let progress = ExtractProgress {
-            current: 50,
-            total: 100,
-            current_path: "test/path.bin",
+    fn progress(done: usize, total: usize) -> ExtractProgress<'static> {
+        ExtractProgress {
+            done,
+            total,
             path_hash: 0x1234,
-        };
-
-        assert!((progress.percent() - 0.5).abs() < f64::EPSILON);
-        assert_eq!(progress.current_path(), "test/path.bin");
+            path: "test/path.bin",
+            result: ExtractResult::Extracted,
+            bytes: 42,
+        }
     }
 
     #[test]
-    fn test_extract_progress_at_boundaries() {
-        // Start
-        let start = ExtractProgress {
-            current: 0,
-            total: 100,
-            current_path: "test.bin",
-            path_hash: 0,
-        };
-        assert!((start.percent() - 0.0).abs() < f64::EPSILON);
-
-        // End
-        let end = ExtractProgress {
-            current: 100,
-            total: 100,
-            current_path: "test.bin",
-            path_hash: 0,
-        };
-        assert!((end.percent() - 1.0).abs() < f64::EPSILON);
+    fn fraction_is_done_over_total() {
+        assert!((progress(50, 100).fraction() - 0.5).abs() < f64::EPSILON);
+        assert!((progress(0, 100).fraction() - 0.0).abs() < f64::EPSILON);
+        assert!((progress(100, 100).fraction() - 1.0).abs() < f64::EPSILON);
+        assert!((progress(0, 0).fraction() - 0.0).abs() < f64::EPSILON);
     }
 
     #[test]
-    fn test_extract_progress_zero_total() {
-        let progress = ExtractProgress {
-            current: 0,
-            total: 0,
-            current_path: "test.bin",
-            path_hash: 0,
-        };
+    fn progress_accessors_read_the_fields() {
+        let progress = progress(1, 2);
 
-        // Should not panic, returns 0.0
-        assert!((progress.percent() - 0.0).abs() < f64::EPSILON);
+        assert_eq!(progress.done(), 1);
+        assert_eq!(progress.total(), 2);
+        assert_eq!(progress.path_hash(), 0x1234);
+        assert_eq!(progress.path(), "test/path.bin");
+        assert_eq!(progress.result(), ExtractResult::Extracted);
+        assert_eq!(progress.bytes(), 42);
     }
 
     // =============================================================================
@@ -1258,42 +1259,19 @@ mod tests {
     fn test_extract_uncompressed_chunk() {
         let temp_dir = tempfile::TempDir::new().unwrap();
         let output_path = Utf8Path::from_path(temp_dir.path()).unwrap();
+        let (mut wad, resolver) =
+            one_chunk_wad(0x1234567890abcdef, "test/hello.txt", b"Hello, World!");
 
-        // Create mock WAD source with test data
-        let test_data = b"Hello, World!";
-        let mut source = MockWadSource::new();
-        let offset = source.write_at(1000, test_data);
-
-        let chunk = create_uncompressed_chunk(0x1234567890abcdef, offset, test_data);
-        let chunks = WadChunks::from_iter([chunk]);
-
-        // Create resolver and extractor
-        let mut resolver = HashMapPathResolver::default();
-        resolver.insert(0x1234567890abcdef, "test/hello.txt".to_string());
-
-        let extractor = WadExtractor::new(&resolver);
-
-        let mut wad = source.into_wad(chunks);
-        let chunk = *wad.chunks().iter().next().unwrap();
-        let chunk_data = wad.load_chunk_decompressed(&chunk).unwrap();
-
-        let result = extractor
-            .extract_chunk_data(
-                &chunk,
-                &chunk_data,
-                Utf8Path::new("test/hello.txt"),
-                output_path,
-            )
+        let report = WadExtractor::new(&resolver)
+            .extract_all(&mut wad, output_path)
             .unwrap();
 
-        assert_eq!(result, ExtractResult::Extracted);
-
-        // Verify file was created with correct content
+        assert_eq!(report.extracted, 1);
         let extracted_path = temp_dir.path().join("test/hello.txt");
-        assert!(extracted_path.exists());
-
-        let content = fs::read_to_string(&extracted_path).unwrap();
-        assert_eq!(content, "Hello, World!");
+        assert_eq!(
+            fs::read_to_string(&extracted_path).unwrap(),
+            "Hello, World!"
+        );
     }
 
     #[test]
@@ -1301,79 +1279,36 @@ mod tests {
         let temp_dir = tempfile::TempDir::new().unwrap();
         let output_path = Utf8Path::from_path(temp_dir.path()).unwrap();
 
-        // Create mock WAD source with gzip-compressed test data
         let test_data = b"This is gzip compressed data!";
         let mut source = MockWadSource::new();
         let (offset, compressed_size) = source.write_gzip_at(1000, test_data);
-
         let chunk = create_gzip_chunk(0xabcdef1234567890, offset, compressed_size, test_data.len());
-        let chunks = WadChunks::from_iter([chunk]);
+        let mut wad = source.into_wad(WadChunks::from_iter([chunk]));
+        let resolver = names(&[(0xabcdef1234567890, "compressed/data.txt")]);
 
-        // Create resolver and extractor
-        let mut resolver = HashMapPathResolver::default();
-        resolver.insert(0xabcdef1234567890, "compressed/data.txt".to_string());
-
-        let extractor = WadExtractor::new(&resolver);
-
-        let mut wad = source.into_wad(chunks);
-        let chunk = *wad.chunks().iter().next().unwrap();
-        let chunk_data = wad.load_chunk_decompressed(&chunk).unwrap();
-
-        let result = extractor
-            .extract_chunk_data(
-                &chunk,
-                &chunk_data,
-                Utf8Path::new("compressed/data.txt"),
-                output_path,
-            )
+        let report = WadExtractor::new(&resolver)
+            .extract_all(&mut wad, output_path)
             .unwrap();
 
-        assert_eq!(result, ExtractResult::Extracted);
-
-        // Verify file was created with correct content
+        assert_eq!(report.extracted, 1);
         let extracted_path = temp_dir.path().join("compressed/data.txt");
-        assert!(extracted_path.exists());
-
-        let content = fs::read_to_string(&extracted_path).unwrap();
-        assert_eq!(content, "This is gzip compressed data!");
+        assert_eq!(
+            fs::read_to_string(&extracted_path).unwrap(),
+            "This is gzip compressed data!"
+        );
     }
 
     #[test]
     fn test_extract_all_chunks() {
         let temp_dir = tempfile::TempDir::new().unwrap();
         let output_path = Utf8Path::from_path(temp_dir.path()).unwrap();
+        let (mut wad, resolver) = three_file_wad();
 
-        // Create mock WAD source with multiple chunks
-        let mut source = MockWadSource::new();
-
-        let data1 = b"File one content";
-        let data2 = b"File two content";
-        let data3 = b"File three content";
-
-        let offset1 = source.write_at(1000, data1);
-        let offset2 = source.write_at(2000, data2);
-        let offset3 = source.write_at(3000, data3);
-
-        let chunk1 = create_uncompressed_chunk(0x1111, offset1, data1);
-        let chunk2 = create_uncompressed_chunk(0x2222, offset2, data2);
-        let chunk3 = create_uncompressed_chunk(0x3333, offset3, data3);
-
-        let chunks = WadChunks::from_iter([chunk1, chunk2, chunk3]);
-
-        // Create resolver
-        let mut resolver = HashMapPathResolver::default();
-        resolver.insert(0x1111, "dir1/file1.txt".to_string());
-        resolver.insert(0x2222, "dir2/file2.txt".to_string());
-        resolver.insert(0x3333, "dir3/file3.txt".to_string());
-
-        let extractor = WadExtractor::new(&resolver);
-
-        let mut wad = source.into_wad(chunks);
-        let report = extractor.extract_all(&mut wad, output_path).unwrap();
+        let report = WadExtractor::new(&resolver)
+            .extract_all(&mut wad, output_path)
+            .unwrap();
 
         assert_eq!(report.extracted, 3);
-
-        // Verify all files were created
         assert!(temp_dir.path().join("dir1/file1.txt").exists());
         assert!(temp_dir.path().join("dir2/file2.txt").exists());
         assert!(temp_dir.path().join("dir3/file3.txt").exists());
@@ -1384,33 +1319,21 @@ mod tests {
         let temp_dir = tempfile::TempDir::new().unwrap();
         let output_path = Utf8Path::from_path(temp_dir.path()).unwrap();
 
-        // Create mock WAD source with multiple chunks
         let mut source = MockWadSource::new();
-
-        let data1 = b"Assets file";
-        let data2 = b"Data file";
-
-        let offset1 = source.write_at(1000, data1);
-        let offset2 = source.write_at(2000, data2);
-
-        let chunk1 = create_uncompressed_chunk(0x1111, offset1, data1);
-        let chunk2 = create_uncompressed_chunk(0x2222, offset2, data2);
-
-        let chunks = WadChunks::from_iter([chunk1, chunk2]);
-
-        // Create resolver
-        let mut resolver = HashMapPathResolver::default();
-        resolver.insert(0x1111, "assets/file1.txt".to_string());
-        resolver.insert(0x2222, "data/file2.txt".to_string());
-
-        // Create extractor with prefix filter
-        let filter = PrefixFilter::new("assets/");
-        let extractor = WadExtractor::new(&resolver).with_filter(filter);
-
+        let offset1 = source.write_at(1000, b"Assets file");
+        let offset2 = source.write_at(2000, b"Data file");
+        let chunks = WadChunks::from_iter([
+            create_uncompressed_chunk(0x1111, offset1, b"Assets file"),
+            create_uncompressed_chunk(0x2222, offset2, b"Data file"),
+        ]);
         let mut wad = source.into_wad(chunks);
-        let report = extractor.extract_all(&mut wad, output_path).unwrap();
+        let resolver = names(&[(0x1111, "assets/file1.txt"), (0x2222, "data/file2.txt")]);
 
-        // Only assets/ file should be extracted
+        let report = WadExtractor::new(&resolver)
+            .with_filter(|path| path.starts_with("assets/"))
+            .extract_all(&mut wad, output_path)
+            .unwrap();
+
         assert_eq!(report.extracted, 1);
         assert_eq!(report.skipped_by_filter, 1);
         assert!(temp_dir.path().join("assets/file1.txt").exists());
@@ -1422,37 +1345,22 @@ mod tests {
         let temp_dir = tempfile::TempDir::new().unwrap();
         let output_path = Utf8Path::from_path(temp_dir.path()).unwrap();
 
-        // Create mock WAD source
         let mut source = MockWadSource::new();
-
-        // PNG magic bytes + some data
-        let png_data = [
-            0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, // PNG header
-            0x00, 0x00, 0x00, 0x00, // Extra data
-        ];
-        // Random non-PNG data
         let other_data = b"Random text data";
-
-        let offset1 = source.write_at(1000, &png_data);
+        let offset1 = source.write_at(1000, &PNG_MAGIC);
         let offset2 = source.write_at(2000, other_data);
-
-        let chunk1 = create_uncompressed_chunk(0x1111, offset1, &png_data);
-        let chunk2 = create_uncompressed_chunk(0x2222, offset2, other_data);
-
-        let chunks = WadChunks::from_iter([chunk1, chunk2]);
-
-        // Create resolver
-        let mut resolver = HashMapPathResolver::default();
-        resolver.insert(0x1111, "images/test.png".to_string());
-        resolver.insert(0x2222, "text/readme.txt".to_string());
-
-        // Create extractor with type filter (only PNG)
-        let extractor = WadExtractor::new(&resolver).with_type_filter(vec![LeagueFileKind::Png]);
-
+        let chunks = WadChunks::from_iter([
+            create_uncompressed_chunk(0x1111, offset1, &PNG_MAGIC),
+            create_uncompressed_chunk(0x2222, offset2, other_data),
+        ]);
         let mut wad = source.into_wad(chunks);
-        let report = extractor.extract_all(&mut wad, output_path).unwrap();
+        let resolver = names(&[(0x1111, "images/test.png"), (0x2222, "text/readme.txt")]);
 
-        // Only PNG file should be extracted
+        let report = WadExtractor::new(&resolver)
+            .with_type_filter([LeagueFileKind::Png])
+            .extract_all(&mut wad, output_path)
+            .unwrap();
+
         assert_eq!(report.extracted, 1);
         assert_eq!(report.skipped_by_filter, 1);
         assert!(temp_dir.path().join("images/test.png").exists());
@@ -1461,38 +1369,27 @@ mod tests {
 
     #[test]
     fn test_extract_progress_callback() {
-        use std::sync::atomic::{AtomicUsize, Ordering};
-        use std::sync::Arc;
-
         let temp_dir = tempfile::TempDir::new().unwrap();
         let output_path = Utf8Path::from_path(temp_dir.path()).unwrap();
+        let (mut wad, resolver) = one_chunk_wad(0x1234, "test.txt", b"Test data");
 
-        // Create mock WAD source
-        let mut source = MockWadSource::new();
-        let data = b"Test data";
-        let offset = source.write_at(1000, data);
-
-        let chunk = create_uncompressed_chunk(0x1234, offset, data);
-        let chunks = WadChunks::from_iter([chunk]);
-
-        let mut resolver = HashMapPathResolver::default();
-        resolver.insert(0x1234, "test.txt".to_string());
-
-        // Track progress calls
-        let progress_count = Arc::new(AtomicUsize::new(0));
-        let progress_count_clone = progress_count.clone();
-
-        let extractor = WadExtractor::new(&resolver).on_progress(move |progress| {
-            progress_count_clone.fetch_add(1, Ordering::SeqCst);
-            assert_eq!(progress.total, 1);
-            assert_eq!(progress.current_path(), "test.txt");
+        let mut seen = Vec::new();
+        let mut extractor = WadExtractor::new(&resolver).on_progress(|progress| {
+            seen.push((
+                progress.done(),
+                progress.total(),
+                progress.path().to_owned(),
+                progress.result(),
+                progress.bytes(),
+            ));
         });
-
-        let mut wad = source.into_wad(chunks);
         extractor.extract_all(&mut wad, output_path).unwrap();
+        drop(extractor);
 
-        // Progress callback should have been called once
-        assert_eq!(progress_count.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            seen,
+            vec![(1, 1, "test.txt".to_owned(), ExtractResult::Extracted, 9)]
+        );
     }
 
     #[test]
@@ -1500,76 +1397,43 @@ mod tests {
         let temp_dir = tempfile::TempDir::new().unwrap();
         let output_path = Utf8Path::from_path(temp_dir.path()).unwrap();
 
-        // Create mock WAD source with PNG data
         let mut source = MockWadSource::new();
-        let png_data = [
-            0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, // PNG header
-            0x00, 0x00, 0x00, 0x00,
-        ];
-        let offset = source.write_at(1000, &png_data);
+        let offset = source.write_at(1000, &PNG_MAGIC);
+        let chunk = create_uncompressed_chunk(0x1234567890abcdef, offset, &PNG_MAGIC);
+        let mut wad = source.into_wad(WadChunks::from_iter([chunk]));
 
-        let chunk = create_uncompressed_chunk(0x1234567890abcdef, offset, &png_data);
-        let chunks = WadChunks::from_iter([chunk]);
-
-        // Use HexPathResolver - no known path, just hex
-        let resolver = HexPathResolver;
-        let extractor = WadExtractor::new(&resolver);
-
-        let mut wad = source.into_wad(chunks);
-        let chunk = *wad.chunks().iter().next().unwrap();
-        let chunk_data = wad.load_chunk_decompressed(&chunk).unwrap();
-
-        let result = extractor
-            .extract_chunk_data(
-                &chunk,
-                &chunk_data,
-                Utf8Path::new("1234567890abcdef"),
-                output_path,
-            )
+        let report = WadExtractor::new(&NoResolver)
+            .extract_all(&mut wad, output_path)
             .unwrap();
 
-        assert_eq!(result, ExtractResult::Extracted);
-
-        // File should have .png extension added based on magic bytes
+        assert_eq!(report.extracted, 1);
         assert!(temp_dir.path().join("1234567890abcdef.png").exists());
+    }
+
+    #[test]
+    fn a_named_path_with_a_hex_stem_keeps_its_name() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let output_path = Utf8Path::from_path(temp_dir.path()).unwrap();
+        let (mut wad, resolver) = one_chunk_wad(0x1234, "assets/0123456789abcdef.txt", &PNG_MAGIC);
+
+        WadExtractor::new(&resolver)
+            .extract_all(&mut wad, output_path)
+            .unwrap();
+
+        assert!(temp_dir.path().join("assets/0123456789abcdef.txt").exists());
+        assert!(!temp_dir.path().join("assets/0123456789abcdef.png").exists());
     }
 
     #[test]
     fn test_extract_path_without_extension_gets_ltk() {
         let temp_dir = tempfile::TempDir::new().unwrap();
         let output_path = Utf8Path::from_path(temp_dir.path()).unwrap();
+        let (mut wad, resolver) = one_chunk_wad(0x1234, "assets/noextension", &PNG_MAGIC);
 
-        // Create mock WAD source with PNG data (known type)
-        let mut source = MockWadSource::new();
-        let png_data = [
-            0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x00,
-        ];
-        let offset = source.write_at(1000, &png_data);
-
-        let chunk = create_uncompressed_chunk(0x1234, offset, &png_data);
-        let chunks = WadChunks::from_iter([chunk]);
-
-        let mut resolver = HashMapPathResolver::default();
-        resolver.insert(0x1234, "assets/noextension".to_string());
-
-        let extractor = WadExtractor::new(&resolver);
-
-        let mut wad = source.into_wad(chunks);
-        let chunk = *wad.chunks().iter().next().unwrap();
-        let chunk_data = wad.load_chunk_decompressed(&chunk).unwrap();
-
-        let result = extractor
-            .extract_chunk_data(
-                &chunk,
-                &chunk_data,
-                Utf8Path::new("assets/noextension"),
-                output_path,
-            )
+        WadExtractor::new(&resolver)
+            .extract_all(&mut wad, output_path)
             .unwrap();
 
-        assert_eq!(result, ExtractResult::Extracted);
-
-        // File should have .ltk.png suffix
         assert!(temp_dir.path().join("assets/noextension.ltk.png").exists());
     }
 
@@ -1577,36 +1441,13 @@ mod tests {
     fn test_extract_path_without_extension_unknown_type() {
         let temp_dir = tempfile::TempDir::new().unwrap();
         let output_path = Utf8Path::from_path(temp_dir.path()).unwrap();
+        let (mut wad, resolver) =
+            one_chunk_wad(0x1234, "assets/noextension", b"Unknown file type content");
 
-        // Create mock WAD source with unknown data
-        let mut source = MockWadSource::new();
-        let unknown_data = b"Unknown file type content";
-        let offset = source.write_at(1000, unknown_data);
-
-        let chunk = create_uncompressed_chunk(0x1234, offset, unknown_data);
-        let chunks = WadChunks::from_iter([chunk]);
-
-        let mut resolver = HashMapPathResolver::default();
-        resolver.insert(0x1234, "assets/noextension".to_string());
-
-        let extractor = WadExtractor::new(&resolver);
-
-        let mut wad = source.into_wad(chunks);
-        let chunk = *wad.chunks().iter().next().unwrap();
-        let chunk_data = wad.load_chunk_decompressed(&chunk).unwrap();
-
-        let result = extractor
-            .extract_chunk_data(
-                &chunk,
-                &chunk_data,
-                Utf8Path::new("assets/noextension"),
-                output_path,
-            )
+        WadExtractor::new(&resolver)
+            .extract_all(&mut wad, output_path)
             .unwrap();
 
-        assert_eq!(result, ExtractResult::Extracted);
-
-        // File should have only .ltk suffix (no type extension)
         assert!(temp_dir.path().join("assets/noextension.ltk").exists());
     }
 
@@ -1614,33 +1455,13 @@ mod tests {
     fn test_extract_creates_nested_directories() {
         let temp_dir = tempfile::TempDir::new().unwrap();
         let output_path = Utf8Path::from_path(temp_dir.path()).unwrap();
+        let (mut wad, resolver) =
+            one_chunk_wad(0x1234, "a/b/c/d/e/deep.txt", b"Deeply nested file");
 
-        let mut source = MockWadSource::new();
-        let data = b"Deeply nested file";
-        let offset = source.write_at(1000, data);
-
-        let chunk = create_uncompressed_chunk(0x1234, offset, data);
-        let chunks = WadChunks::from_iter([chunk]);
-
-        let mut resolver = HashMapPathResolver::default();
-        resolver.insert(0x1234, "a/b/c/d/e/deep.txt".to_string());
-
-        let extractor = WadExtractor::new(&resolver);
-
-        let mut wad = source.into_wad(chunks);
-        let chunk = *wad.chunks().iter().next().unwrap();
-        let chunk_data = wad.load_chunk_decompressed(&chunk).unwrap();
-
-        let result = extractor
-            .extract_chunk_data(
-                &chunk,
-                &chunk_data,
-                Utf8Path::new("a/b/c/d/e/deep.txt"),
-                output_path,
-            )
+        WadExtractor::new(&resolver)
+            .extract_all(&mut wad, output_path)
             .unwrap();
 
-        assert_eq!(result, ExtractResult::Extracted);
         assert!(temp_dir.path().join("a/b/c/d/e/deep.txt").exists());
     }
 
@@ -1648,37 +1469,30 @@ mod tests {
     fn test_extract_empty_chunks_returns_zero() {
         let temp_dir = tempfile::TempDir::new().unwrap();
         let output_path = Utf8Path::from_path(temp_dir.path()).unwrap();
+        let mut wad = MockWadSource::new().into_wad(WadChunks::from_iter([]));
 
-        let source = MockWadSource::new();
-        let chunks = WadChunks::from_iter([]);
-
-        let resolver = HexPathResolver;
-        let extractor = WadExtractor::new(&resolver);
-
-        let mut wad = source.into_wad(chunks);
-        let report = extractor.extract_all(&mut wad, output_path).unwrap();
+        let report = WadExtractor::new(&NoResolver)
+            .extract_all(&mut wad, output_path)
+            .unwrap();
 
         assert_eq!(report, ExtractReport::default());
     }
 
     #[test]
-    fn test_extractor_builder_pattern() {
-        use std::sync::atomic::{AtomicBool, Ordering};
-        use std::sync::Arc;
+    fn the_builder_takes_a_filter_on_a_condition() {
+        let resolver = NoResolver;
+        let mut extractor = WadExtractor::new(&resolver)
+            .with_type_filter([LeagueFileKind::Png, LeagueFileKind::Jpeg])
+            .on_progress(|_| {});
 
-        let resolver = HexPathResolver;
-        let called = Arc::new(AtomicBool::new(false));
-        let called_clone = called.clone();
+        let only_assets = true;
+        if only_assets {
+            extractor = extractor.with_filter(|path| path.starts_with("assets/"));
+        }
 
-        // Test that builder pattern works correctly
-        let _extractor = WadExtractor::new(&resolver)
-            .with_filter(PrefixFilter::new("assets/"))
-            .with_type_filter(vec![LeagueFileKind::Png, LeagueFileKind::Jpeg])
-            .on_progress(move |_| {
-                called_clone.store(true, Ordering::SeqCst);
-            });
-
-        // Builder compiles and type inference works
+        let debug = format!("{extractor:?}");
+        assert!(debug.contains("WadExtractor"));
+        assert!(debug.contains("has_filter: true"));
     }
 
     // =============================================================================
@@ -1688,7 +1502,7 @@ mod tests {
     const PNG_MAGIC: [u8; 12] = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0, 0, 0, 0];
 
     /// Three uncompressed text chunks, each under a directory of its own.
-    fn three_file_wad() -> (Wad<MockWadSource>, HashMapPathResolver) {
+    fn three_file_wad() -> (Wad<MockWadSource>, HashMap<u64, String>) {
         let mut source = MockWadSource::new();
         let offset1 = source.write_at(1000, b"File one content");
         let offset2 = source.write_at(2000, b"File two content");
@@ -1700,10 +1514,11 @@ mod tests {
             create_uncompressed_chunk(0x3333, offset3, b"File three content"),
         ]);
 
-        let mut resolver = HashMapPathResolver::default();
-        resolver.insert(0x1111, "dir1/file1.txt".to_string());
-        resolver.insert(0x2222, "dir2/file2.txt".to_string());
-        resolver.insert(0x3333, "dir3/file3.txt".to_string());
+        let resolver = names(&[
+            (0x1111, "dir1/file1.txt"),
+            (0x2222, "dir2/file2.txt"),
+            (0x3333, "dir3/file3.txt"),
+        ]);
 
         (source.into_wad(chunks), resolver)
     }
@@ -1721,12 +1536,9 @@ mod tests {
             create_uncompressed_chunk(0x1111, offset1, &PNG_MAGIC),
             create_uncompressed_chunk(0x2222, offset2, text),
         ]);
-
-        let mut resolver = HashMapPathResolver::default();
-        resolver.insert(0x1111, "images/test.png".to_string());
-        resolver.insert(0x2222, "text/readme.txt".to_string());
-
         let mut wad = source.into_wad(chunks);
+        let resolver = names(&[(0x1111, "images/test.png"), (0x2222, "text/readme.txt")]);
+
         let report = WadExtractor::new(&resolver)
             .extract_all(&mut wad, output_path)
             .unwrap();
@@ -1734,10 +1546,32 @@ mod tests {
         assert_eq!(report.extracted, 2);
         assert_eq!(report.skipped_existing, 0);
         assert_eq!(report.skipped_by_filter, 0);
+        assert!(report.missing.is_empty());
         assert_eq!(report.bytes_written, (PNG_MAGIC.len() + text.len()) as u64);
         assert_eq!(report.by_kind.get(&LeagueFileKind::Png), Some(&1));
         assert_eq!(report.by_kind.values().sum::<usize>(), 2);
         assert!(!report.cancelled);
+        assert!(report.recovered.is_empty());
+    }
+
+    #[test]
+    fn the_report_displays_its_counts() {
+        assert_eq!(ExtractReport::default().to_string(), "0 extracted, 0 bytes");
+
+        let report = ExtractReport {
+            extracted: 2,
+            bytes_written: 40,
+            skipped_existing: 1,
+            skipped_by_filter: 3,
+            missing: vec![0x9999],
+            cancelled: true,
+            ..Default::default()
+        };
+
+        assert_eq!(
+            report.to_string(),
+            "2 extracted, 40 bytes, 1 existed, 3 filtered out, 1 missing, cancelled"
+        );
     }
 
     #[test]
@@ -1746,18 +1580,34 @@ mod tests {
         let output_path = Utf8Path::from_path(temp_dir.path()).unwrap();
         let (mut wad, resolver) = three_file_wad();
 
-        let wanted = [
-            *wad.chunks().get(0x1111).unwrap(),
-            *wad.chunks().get(0x3333).unwrap(),
-        ];
         let report = WadExtractor::new(&resolver)
-            .extract_chunks(&mut wad, &wanted, output_path)
+            .extract_chunks(&mut wad, [0x1111, 0x3333], output_path)
             .unwrap();
 
         assert_eq!(report.extracted, 2);
         assert!(temp_dir.path().join("dir1/file1.txt").exists());
         assert!(!temp_dir.path().join("dir2/file2.txt").exists());
         assert!(temp_dir.path().join("dir3/file3.txt").exists());
+    }
+
+    #[test]
+    fn extract_chunks_lists_the_hashes_the_archive_lacks() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let output_path = Utf8Path::from_path(temp_dir.path()).unwrap();
+        let (mut wad, resolver) = three_file_wad();
+
+        let mut totals = Vec::new();
+        let mut extractor = WadExtractor::new(&resolver).on_progress(|progress| {
+            totals.push(progress.total());
+        });
+        let report = extractor
+            .extract_chunks(&mut wad, [0x1111, 0x9999, 0x1111], output_path)
+            .unwrap();
+        drop(extractor);
+
+        assert_eq!(report.extracted, 1);
+        assert_eq!(report.missing, vec![0x9999]);
+        assert_eq!(totals, vec![1]);
     }
 
     #[test]
@@ -1790,13 +1640,10 @@ mod tests {
             create_uncompressed_chunk(0x1111, offset1, b"first"),
             create_uncompressed_chunk(0x2222, offset2, b"second"),
         ]);
-
-        let mut resolver = HashMapPathResolver::default();
-        resolver.insert(0x1111, "a/same.txt".to_string());
-        resolver.insert(0x2222, "b/same.txt".to_string());
+        let mut wad = source.into_wad(chunks);
+        let resolver = names(&[(0x1111, "a/same.txt"), (0x2222, "b/same.txt")]);
 
         // One worker, so the chunks land in the order they are read.
-        let mut wad = source.into_wad(chunks);
         let report = WadExtractor::new(&resolver)
             .with_layout(ExtractLayout::Flat)
             .with_workers(NonZeroUsize::new(1).unwrap())
@@ -1812,6 +1659,25 @@ mod tests {
             fs::read_to_string(temp_dir.path().join("same.0000000000002222.txt")).unwrap(),
             "second"
         );
+    }
+
+    #[test]
+    fn a_second_extraction_starts_with_no_flat_names() {
+        let first_dir = tempfile::TempDir::new().unwrap();
+        let second_dir = tempfile::TempDir::new().unwrap();
+        let (mut wad, resolver) = three_file_wad();
+
+        let mut extractor = WadExtractor::new(&resolver).with_layout(ExtractLayout::Flat);
+        extractor
+            .extract_all(&mut wad, Utf8Path::from_path(first_dir.path()).unwrap())
+            .unwrap();
+        let report = extractor
+            .extract_all(&mut wad, Utf8Path::from_path(second_dir.path()).unwrap())
+            .unwrap();
+
+        assert_eq!(report.extracted, 3);
+        assert!(second_dir.path().join("file1.txt").exists());
+        assert_eq!(fs::read_dir(second_dir.path()).unwrap().count(), 3);
     }
 
     #[test]
@@ -1871,72 +1737,66 @@ mod tests {
     }
 
     #[test]
-    fn extract_chunk_data_honors_the_skip_policy() {
+    fn progress_reports_each_chunk_once_it_is_done() {
         let temp_dir = tempfile::TempDir::new().unwrap();
         let output_path = Utf8Path::from_path(temp_dir.path()).unwrap();
+        let (mut wad, resolver) = three_file_wad();
 
-        let existing = temp_dir.path().join("test/hello.txt");
-        fs::create_dir_all(existing.parent().unwrap()).unwrap();
-        fs::write(&existing, "kept").unwrap();
+        let mut seen = Vec::new();
+        let mut extractor = WadExtractor::new(&resolver)
+            .with_filter(|path| !path.starts_with("dir2/"))
+            .on_progress(|progress| {
+                seen.push((
+                    progress.done(),
+                    progress.total(),
+                    progress.path().to_owned(),
+                    progress.result(),
+                ));
+            });
+        extractor.extract_all(&mut wad, output_path).unwrap();
+        drop(extractor);
 
-        let mut source = MockWadSource::new();
-        let data = b"Hello, World!";
-        let offset = source.write_at(1000, data);
-        let chunk = create_uncompressed_chunk(0x1234, offset, data);
+        assert_eq!(
+            seen.iter().map(|(done, ..)| *done).collect::<Vec<_>>(),
+            vec![1, 2, 3]
+        );
+        assert!(seen.iter().all(|(_, total, ..)| *total == 3));
 
-        let resolver = HexPathResolver;
-        let extractor =
-            WadExtractor::new(&resolver).with_existing_file_policy(ExistingFilePolicy::Skip);
-
-        let result = extractor
-            .extract_chunk_data(&chunk, data, Utf8Path::new("test/hello.txt"), output_path)
-            .unwrap();
-
-        assert_eq!(result, ExtractResult::SkippedExisting);
-        assert_eq!(fs::read_to_string(&existing).unwrap(), "kept");
+        let mut by_path: Vec<_> = seen
+            .iter()
+            .map(|(_, _, path, result)| (path.as_str(), *result))
+            .collect();
+        by_path.sort_by(|a, b| a.0.cmp(b.0));
+        assert_eq!(
+            by_path,
+            vec![
+                ("dir1/file1.txt", ExtractResult::Extracted),
+                ("dir2/file2.txt", ExtractResult::SkippedByPath),
+                ("dir3/file3.txt", ExtractResult::Extracted),
+            ]
+        );
     }
 
-    // =============================================================================
-    // Regex Filter Tests (feature-gated)
-    // =============================================================================
+    #[test]
+    fn a_failed_write_names_the_chunk() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let output_path = Utf8Path::from_path(temp_dir.path()).unwrap();
+        let (mut wad, resolver) = three_file_wad();
 
-    #[cfg(feature = "regex")]
-    mod regex_tests {
-        use super::*;
+        /* A file where the first chunk's directory has to go. */
+        fs::write(temp_dir.path().join("dir1"), "in the way").unwrap();
 
-        #[test]
-        fn test_regex_filter_matches_pattern() {
-            let filter = RegexFilter::new(r"^assets/.*\.bin$").unwrap();
+        let error = WadExtractor::new(&resolver)
+            .extract_all(&mut wad, output_path)
+            .unwrap_err();
 
-            assert!(filter.matches("assets/champions/aatrox.bin"));
-            assert!(filter.matches("assets/test.bin"));
-            assert!(!filter.matches("data/test.bin"));
-            assert!(!filter.matches("assets/test.png"));
-        }
-
-        #[test]
-        fn test_regex_filter_complex_patterns() {
-            let filter = RegexFilter::new(r"champions/(aatrox|ahri|akali)/").unwrap();
-
-            assert!(filter.matches("assets/champions/aatrox/skin0.bin"));
-            assert!(filter.matches("data/champions/ahri/animations.anm"));
-            assert!(filter.matches("champions/akali/test"));
-            assert!(!filter.matches("champions/ashe/test"));
-        }
-
-        #[test]
-        fn test_regex_filter_invalid_pattern_returns_none() {
-            let filter = RegexFilter::new(r"[invalid");
-            assert!(filter.is_none());
-        }
-
-        #[test]
-        fn test_regex_filter_from_compiled_regex() {
-            let regex = regex::Regex::new(r"\.png$").unwrap();
-            let filter = RegexFilter::from_regex(regex);
-
-            assert!(filter.matches("test.png"));
-            assert!(!filter.matches("test.jpg"));
-        }
+        assert!(
+            matches!(
+                &error,
+                WadError::Chunk { path_hash: 0x1111, path, .. } if path == "dir1/file1.txt"
+            ),
+            "{error:?}"
+        );
+        assert!(error.to_string().contains("dir1/file1.txt"), "{error}");
     }
 }

--- a/crates/ltk_wad/src/extractor.rs
+++ b/crates/ltk_wad/src/extractor.rs
@@ -7,13 +7,13 @@
 //! ```no_run
 //! use std::collections::HashMap;
 //! use std::fs::File;
-//! use ltk_wad::{Wad, WadExtractor};
+//! use ltk_wad::{Wad, WadExtractor, WadHash};
 //!
 //! let file = File::open("archive.wad.client")?;
 //! let mut wad = Wad::mount(file)?;
 //!
-//! // Any `HashMap<u64, String>` is a resolver. Load a hash table into one.
-//! let names: HashMap<u64, String> = HashMap::new();
+//! // Any `HashMap<WadHash, String>` is a resolver. Load a hash table into one.
+//! let names: HashMap<WadHash, String> = HashMap::new();
 //!
 //! let mut extractor = WadExtractor::new(&names).on_progress(|progress| {
 //!     println!("{:.1}% {}", progress.fraction() * 100.0, progress.path());
@@ -31,12 +31,12 @@
 //!
 //! ```no_run
 //! use std::fs::File;
-//! use ltk_wad::{Wad, WadExtractor, NoResolver, ExtractLayout, ExistingFilePolicy};
+//! use ltk_wad::{Wad, WadExtractor, WadHash, NoResolver, ExtractLayout, ExistingFilePolicy};
 //!
 //! let file = File::open("archive.wad.client")?;
 //! let mut wad = Wad::mount(file)?;
 //!
-//! let wanted = [0x1234567890abcdef_u64, 0xfedcba0987654321];
+//! let wanted = [WadHash(0x1234567890abcdef), WadHash(0xfedcba0987654321)];
 //! let mut extractor = WadExtractor::new(&NoResolver)
 //!     .with_layout(ExtractLayout::Flat)
 //!     .with_existing_file_policy(ExistingFilePolicy::Skip);
@@ -88,6 +88,7 @@ use std::{
 
 use camino::{Utf8Path, Utf8PathBuf};
 use ltk_file::LeagueFileKind;
+use ltk_hash::WadHash;
 
 use crate::{ChunkDecoder, NameRecovery, RecoveredNames, Wad, WadChunk, WadError};
 
@@ -98,58 +99,58 @@ use crate::{ChunkDecoder, NameRecovery, RecoveredNames, Wad, WadChunk, WadError}
 /// `None` for a hash it has no name for. Such a chunk is written under its
 /// hash as sixteen hex digits.
 ///
-/// Every `HashMap<u64, String>` is a resolver, and so is a reference, a `Box`
+/// Every `HashMap<WadHash, String>` is a resolver, and so is a reference, a `Box`
 /// or an `Arc` of any resolver.
 pub trait PathResolver {
     /// The path of `path_hash`, or `None` when the resolver has no name for it.
-    fn resolve(&self, path_hash: u64) -> Option<Cow<'_, str>>;
+    fn resolve(&self, path_hash: WadHash) -> Option<Cow<'_, str>>;
 
     /// Whether the resolver names `path_hash`.
     ///
     /// The default calls [`resolve`](Self::resolve). A resolver that can
     /// answer without building the string should override it.
-    fn is_known(&self, path_hash: u64) -> bool {
+    fn is_known(&self, path_hash: WadHash) -> bool {
         self.resolve(path_hash).is_some()
     }
 }
 
 impl<R: PathResolver + ?Sized> PathResolver for &R {
-    fn resolve(&self, path_hash: u64) -> Option<Cow<'_, str>> {
+    fn resolve(&self, path_hash: WadHash) -> Option<Cow<'_, str>> {
         (**self).resolve(path_hash)
     }
 
-    fn is_known(&self, path_hash: u64) -> bool {
+    fn is_known(&self, path_hash: WadHash) -> bool {
         (**self).is_known(path_hash)
     }
 }
 
 impl<R: PathResolver + ?Sized> PathResolver for Box<R> {
-    fn resolve(&self, path_hash: u64) -> Option<Cow<'_, str>> {
+    fn resolve(&self, path_hash: WadHash) -> Option<Cow<'_, str>> {
         (**self).resolve(path_hash)
     }
 
-    fn is_known(&self, path_hash: u64) -> bool {
+    fn is_known(&self, path_hash: WadHash) -> bool {
         (**self).is_known(path_hash)
     }
 }
 
 impl<R: PathResolver + ?Sized> PathResolver for Arc<R> {
-    fn resolve(&self, path_hash: u64) -> Option<Cow<'_, str>> {
+    fn resolve(&self, path_hash: WadHash) -> Option<Cow<'_, str>> {
         (**self).resolve(path_hash)
     }
 
-    fn is_known(&self, path_hash: u64) -> bool {
+    fn is_known(&self, path_hash: WadHash) -> bool {
         (**self).is_known(path_hash)
     }
 }
 
-impl<S: BuildHasher> PathResolver for HashMap<u64, String, S> {
-    fn resolve(&self, path_hash: u64) -> Option<Cow<'_, str>> {
+impl<S: BuildHasher> PathResolver for HashMap<WadHash, String, S> {
+    fn resolve(&self, path_hash: WadHash) -> Option<Cow<'_, str>> {
         self.get(&path_hash)
             .map(|path| Cow::Borrowed(path.as_str()))
     }
 
-    fn is_known(&self, path_hash: u64) -> bool {
+    fn is_known(&self, path_hash: WadHash) -> bool {
         self.contains_key(&path_hash)
     }
 }
@@ -159,17 +160,17 @@ impl<S: BuildHasher> PathResolver for HashMap<u64, String, S> {
 pub struct NoResolver;
 
 impl PathResolver for NoResolver {
-    fn resolve(&self, _path_hash: u64) -> Option<Cow<'_, str>> {
+    fn resolve(&self, _path_hash: WadHash) -> Option<Cow<'_, str>> {
         None
     }
 
-    fn is_known(&self, _path_hash: u64) -> bool {
+    fn is_known(&self, _path_hash: WadHash) -> bool {
         false
     }
 }
 
 /// A path hash as the sixteen hex digits a nameless chunk is written under.
-pub(crate) fn hex_name(path_hash: u64) -> String {
+pub(crate) fn hex_name(path_hash: WadHash) -> String {
     format!("{path_hash:016x}")
 }
 
@@ -178,7 +179,7 @@ pub(crate) fn hex_name(path_hash: u64) -> String {
 pub struct ExtractProgress<'a> {
     done: usize,
     total: usize,
-    path_hash: u64,
+    path_hash: WadHash,
     path: &'a str,
     result: ExtractResult,
     bytes: u64,
@@ -207,7 +208,7 @@ impl ExtractProgress<'_> {
     }
 
     /// The chunk's path hash.
-    pub fn path_hash(&self) -> u64 {
+    pub fn path_hash(&self) -> WadHash {
         self.path_hash
     }
 
@@ -282,7 +283,7 @@ pub struct ExtractReport {
     pub skipped_by_filter: usize,
     /// Path hashes given to [`extract_chunks`](WadExtractor::extract_chunks)
     /// that the archive holds no chunk for.
-    pub missing: Vec<u64>,
+    pub missing: Vec<WadHash>,
     /// Bytes written, after decompression.
     pub bytes_written: u64,
     /// Written chunks, by the kind their bytes identify as.
@@ -519,7 +520,7 @@ impl<'a> WadExtractor<'a> {
     pub fn extract_chunks<S: Read + Seek>(
         &mut self,
         wad: &mut Wad<S>,
-        path_hashes: impl IntoIterator<Item = u64>,
+        path_hashes: impl IntoIterator<Item = WadHash>,
         output_dir: impl AsRef<Utf8Path>,
     ) -> Result<ExtractReport, WadError> {
         let mut seen = HashSet::new();
@@ -541,7 +542,7 @@ impl<'a> WadExtractor<'a> {
         &mut self,
         wad: &mut Wad<S>,
         chunks: Vec<WadChunk>,
-        missing: Vec<u64>,
+        missing: Vec<WadHash>,
         output_dir: &Utf8Path,
     ) -> Result<ExtractReport, WadError> {
         let workers = self.workers.map_or_else(default_workers, NonZeroUsize::get);
@@ -639,7 +640,7 @@ struct Job {
 
 /// One chunk on its way back from a worker, for the progress callback.
 struct Done {
-    path_hash: u64,
+    path_hash: WadHash,
     path: String,
     outcome: ChunkOutcome,
 }
@@ -1067,7 +1068,7 @@ mod tests {
     /// Create a test chunk with uncompressed data.
     fn create_uncompressed_chunk(path_hash: u64, data_offset: usize, data: &[u8]) -> WadChunk {
         WadChunk {
-            path_hash,
+            path_hash: WadHash(path_hash),
             data_offset,
             compressed_size: data.len(),
             uncompressed_size: data.len(),
@@ -1087,7 +1088,7 @@ mod tests {
         uncompressed_size: usize,
     ) -> WadChunk {
         WadChunk {
-            path_hash,
+            path_hash: WadHash(path_hash),
             data_offset,
             compressed_size,
             uncompressed_size,
@@ -1100,10 +1101,10 @@ mod tests {
     }
 
     /// A resolver over the given names.
-    fn names(entries: &[(u64, &str)]) -> HashMap<u64, String> {
+    fn names(entries: &[(u64, &str)]) -> HashMap<WadHash, String> {
         entries
             .iter()
-            .map(|(hash, path)| (*hash, (*path).to_owned()))
+            .map(|(hash, path)| (WadHash(*hash), (*path).to_owned()))
             .collect()
     }
 
@@ -1112,7 +1113,7 @@ mod tests {
         path_hash: u64,
         path: &str,
         data: &[u8],
-    ) -> (Wad<MockWadSource>, HashMap<u64, String>) {
+    ) -> (Wad<MockWadSource>, HashMap<WadHash, String>) {
         let mut source = MockWadSource::new();
         let offset = source.write_at(1000, data);
         let chunks = WadChunks::from_iter([create_uncompressed_chunk(path_hash, offset, data)]);
@@ -1162,18 +1163,21 @@ mod tests {
 
     #[test]
     fn no_resolver_names_nothing() {
-        assert_eq!(NoResolver.resolve(0x0123456789abcdef), None);
-        assert!(!NoResolver.is_known(0x0123456789abcdef));
+        assert_eq!(NoResolver.resolve(WadHash(0x0123456789abcdef)), None);
+        assert!(!NoResolver.is_known(WadHash(0x0123456789abcdef)));
     }
 
     #[test]
     fn a_hash_map_is_a_resolver() {
         let resolver = names(&[(0x1234, "assets/test.bin")]);
 
-        assert_eq!(resolver.resolve(0x1234).as_deref(), Some("assets/test.bin"));
-        assert_eq!(resolver.resolve(0x5678), None);
-        assert!(resolver.is_known(0x1234));
-        assert!(!resolver.is_known(0x5678));
+        assert_eq!(
+            resolver.resolve(WadHash(0x1234)).as_deref(),
+            Some("assets/test.bin")
+        );
+        assert_eq!(resolver.resolve(WadHash(0x5678)), None);
+        assert!(resolver.is_known(WadHash(0x1234)));
+        assert!(!resolver.is_known(WadHash(0x5678)));
     }
 
     #[test]
@@ -1185,9 +1189,9 @@ mod tests {
 
         let resolvers: [&dyn PathResolver; 3] = [&by_ref, &boxed, &shared];
         for resolver in resolvers {
-            assert_eq!(resolver.resolve(0x1).as_deref(), Some("one"));
-            assert!(resolver.is_known(0x1));
-            assert!(!resolver.is_known(0x2));
+            assert_eq!(resolver.resolve(WadHash(0x1)).as_deref(), Some("one"));
+            assert!(resolver.is_known(WadHash(0x1)));
+            assert!(!resolver.is_known(WadHash(0x2)));
         }
     }
 
@@ -1224,7 +1228,7 @@ mod tests {
         ExtractProgress {
             done,
             total,
-            path_hash: 0x1234,
+            path_hash: WadHash(0x1234),
             path: "test/path.bin",
             result: ExtractResult::Extracted,
             bytes: 42,
@@ -1245,7 +1249,7 @@ mod tests {
 
         assert_eq!(progress.done(), 1);
         assert_eq!(progress.total(), 2);
-        assert_eq!(progress.path_hash(), 0x1234);
+        assert_eq!(progress.path_hash(), WadHash(0x1234));
         assert_eq!(progress.path(), "test/path.bin");
         assert_eq!(progress.result(), ExtractResult::Extracted);
         assert_eq!(progress.bytes(), 42);
@@ -1502,7 +1506,7 @@ mod tests {
     const PNG_MAGIC: [u8; 12] = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0, 0, 0, 0];
 
     /// Three uncompressed text chunks, each under a directory of its own.
-    fn three_file_wad() -> (Wad<MockWadSource>, HashMap<u64, String>) {
+    fn three_file_wad() -> (Wad<MockWadSource>, HashMap<WadHash, String>) {
         let mut source = MockWadSource::new();
         let offset1 = source.write_at(1000, b"File one content");
         let offset2 = source.write_at(2000, b"File two content");
@@ -1563,7 +1567,7 @@ mod tests {
             bytes_written: 40,
             skipped_existing: 1,
             skipped_by_filter: 3,
-            missing: vec![0x9999],
+            missing: vec![WadHash(0x9999)],
             cancelled: true,
             ..Default::default()
         };
@@ -1581,7 +1585,7 @@ mod tests {
         let (mut wad, resolver) = three_file_wad();
 
         let report = WadExtractor::new(&resolver)
-            .extract_chunks(&mut wad, [0x1111, 0x3333], output_path)
+            .extract_chunks(&mut wad, [WadHash(0x1111), WadHash(0x3333)], output_path)
             .unwrap();
 
         assert_eq!(report.extracted, 2);
@@ -1600,13 +1604,14 @@ mod tests {
         let mut extractor = WadExtractor::new(&resolver).on_progress(|progress| {
             totals.push(progress.total());
         });
+        let wanted = [WadHash(0x1111), WadHash(0x9999), WadHash(0x1111)];
         let report = extractor
-            .extract_chunks(&mut wad, [0x1111, 0x9999, 0x1111], output_path)
+            .extract_chunks(&mut wad, wanted, output_path)
             .unwrap();
         drop(extractor);
 
         assert_eq!(report.extracted, 1);
-        assert_eq!(report.missing, vec![0x9999]);
+        assert_eq!(report.missing, vec![WadHash(0x9999)]);
         assert_eq!(totals, vec![1]);
     }
 
@@ -1793,7 +1798,7 @@ mod tests {
         assert!(
             matches!(
                 &error,
-                WadError::Chunk { path_hash: 0x1111, path, .. } if path == "dir1/file1.txt"
+                WadError::Chunk { path_hash: WadHash(0x1111), path, .. } if path == "dir1/file1.txt"
             ),
             "{error:?}"
         );

--- a/crates/ltk_wad/src/extractor.rs
+++ b/crates/ltk_wad/src/extractor.rs
@@ -35,24 +35,76 @@
 //!             println!("Progress: {:.1}% - {}", progress.percent() * 100.0, progress.current_path());
 //!         });
 //!
-//!     let extracted = extractor.extract_all(&mut wad, "/output/path")?;
-//!     println!("Extracted {} chunks", extracted);
+//!     let report = extractor.extract_all(&mut wad, "/output/path")?;
+//!     println!("Extracted {} chunks ({} bytes)", report.extracted, report.bytes_written);
 //!
 //!     Ok(())
 //! }
 //! ```
+//!
+//! # Extracting a selection
+//!
+//! [`WadExtractor::extract_chunks`] takes any slice of the archive's chunks, so a
+//! caller that knows which path hashes it wants extracts those alone:
+//!
+//! ```no_run
+//! use std::fs::File;
+//! use ltk_wad::{Wad, WadExtractor, HexPathResolver, ExtractLayout, ExistingFilePolicy};
+//!
+//! let file = File::open("archive.wad.client")?;
+//! let mut wad = Wad::mount(file)?;
+//!
+//! let wanted = [0x1234567890abcdef_u64, 0xfedcba0987654321];
+//! let chunks: Vec<_> = wanted
+//!     .iter()
+//!     .filter_map(|hash| wad.chunks().get(*hash).copied())
+//!     .collect();
+//!
+//! let extractor = WadExtractor::new(&HexPathResolver)
+//!     .with_layout(ExtractLayout::Flat)
+//!     .with_existing_file_policy(ExistingFilePolicy::Skip);
+//! let report = extractor.extract_chunks(&mut wad, &chunks, "/output/path")?;
+//! println!("{} written, {} were there already", report.extracted, report.skipped_existing);
+//! # Ok::<(), Box<dyn std::error::Error>>(())
+//! ```
+//!
+//! # How a chunk is named on disk
+//!
+//! - A path the resolver knows is used as is.
+//! - A path that is a bare hash (16 hex digits) gains the extension its bytes
+//!   identify as, when they identify as anything.
+//! - A path with no extension, or one that collides with an existing directory,
+//!   becomes `<stem>.ltk.<ext>`, or `<stem>.ltk` when the bytes identify as nothing.
+//! - A name the file system refuses as too long falls back to `<hash>.<ext>` in
+//!   the output directory itself.
+//!
+//! # Parallelism
+//!
+//! [`extract_all`](WadExtractor::extract_all) and
+//! [`extract_chunks`](WadExtractor::extract_chunks) read the archive in order on
+//! the calling thread and hand each chunk to a worker that decompresses and
+//! writes it. The channel between the two is bounded by the worker count, so
+//! memory holds a few chunks whatever the archive holds. The resolver, the path
+//! filter and the progress callback run on the calling thread only, so none of
+//! them needs to be [`Sync`].
 
 use std::{
     borrow::Cow,
-    collections::HashMap,
-    fs,
-    io::{self, Read, Seek},
+    collections::{BTreeMap, HashMap, HashSet},
+    fs::{self, OpenOptions},
+    io::{self, Read, Seek, Write as _},
+    num::NonZeroUsize,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        mpsc, Mutex, MutexGuard, PoisonError,
+    },
+    thread,
 };
 
 use camino::{Utf8Path, Utf8PathBuf};
 use ltk_file::LeagueFileKind;
 
-use crate::{Wad, WadChunk, WadError};
+use crate::{decompress_raw, Wad, WadChunk, WadError};
 
 /// A trait for resolving path hashes to human-readable paths.
 ///
@@ -168,10 +220,95 @@ pub enum ExtractResult {
     SkippedByType,
     /// The chunk was skipped due to pattern filtering.
     SkippedByPattern,
+    /// The chunk's file existed already, and the policy was [`ExistingFilePolicy::Skip`].
+    SkippedExisting,
+}
+
+/// Where each extracted chunk lands under the output directory.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ExtractLayout {
+    /// At its resolved path, with every directory of that path.
+    #[default]
+    Paths,
+    /// In the output directory itself, by its file name alone.
+    ///
+    /// When two chunks of one extraction share a name, the second keeps apart
+    /// with its path hash before the extension, as `name.<hash>.ext`. Which of
+    /// the two is second follows write order, so build one extractor per
+    /// extraction when driving [`WadExtractor::extract_chunk_data`] yourself.
+    Flat,
+}
+
+/// What to do with a chunk whose file exists already.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ExistingFilePolicy {
+    /// Write over it.
+    #[default]
+    Overwrite,
+    /// Leave it, and count the chunk under [`ExtractReport::skipped_existing`].
+    ///
+    /// The file is opened with `create_new`, so a file that appears between two
+    /// chunks is left alone too and no check races the write.
+    Skip,
+}
+
+/// What an extraction did, summed over its chunks.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct ExtractReport {
+    /// Chunks written to disk.
+    pub extracted: usize,
+    /// Chunks left alone under [`ExistingFilePolicy::Skip`].
+    pub skipped_existing: usize,
+    /// Chunks the path filter or the type filter left out.
+    pub skipped_by_filter: usize,
+    /// Bytes written, after decompression.
+    pub bytes_written: u64,
+    /// Written chunks, by the kind their bytes identify as.
+    pub by_kind: BTreeMap<LeagueFileKind, usize>,
+    /// The cancel flag was set, so some chunks were never read.
+    pub cancelled: bool,
+}
+
+impl ExtractReport {
+    fn record(&mut self, outcome: ChunkOutcome) {
+        match outcome {
+            ChunkOutcome::Written { kind, bytes } => {
+                self.extracted += 1;
+                self.bytes_written += bytes;
+                *self.by_kind.entry(kind).or_insert(0) += 1;
+            }
+            ChunkOutcome::SkippedByType => self.skipped_by_filter += 1,
+            ChunkOutcome::SkippedExisting => self.skipped_existing += 1,
+        }
+    }
+}
+
+/// What happened to one chunk, with the figures the report sums.
+#[derive(Debug, Clone, Copy)]
+enum ChunkOutcome {
+    Written { kind: LeagueFileKind, bytes: u64 },
+    SkippedByType,
+    SkippedExisting,
+}
+
+impl From<ChunkOutcome> for ExtractResult {
+    fn from(outcome: ChunkOutcome) -> Self {
+        match outcome {
+            ChunkOutcome::Written { .. } => ExtractResult::Extracted,
+            ChunkOutcome::SkippedByType => ExtractResult::SkippedByType,
+            ChunkOutcome::SkippedExisting => ExtractResult::SkippedExisting,
+        }
+    }
 }
 
 /// Type alias for the progress callback function.
 pub type ProgressCallback<'a> = Box<dyn Fn(ExtractProgress<'_>) + 'a>;
+
+/// Most workers an extraction starts unless [`WadExtractor::with_workers`] says
+/// otherwise. Each worker holds a compressed and a decompressed chunk at once,
+/// and a wide machine would otherwise hold dozens of the largest ones.
+const DEFAULT_WORKER_CAP: usize = 8;
 
 /// Configuration and execution of WAD chunk extraction.
 ///
@@ -184,6 +321,13 @@ pub struct WadExtractor<'a, R: PathResolver, F: PathFilter = NoFilter> {
     filter: Option<F>,
     type_filter: Option<Vec<LeagueFileKind>>,
     progress_callback: Option<ProgressCallback<'a>>,
+    layout: ExtractLayout,
+    existing: ExistingFilePolicy,
+    cancel: Option<&'a AtomicBool>,
+    workers: Option<NonZeroUsize>,
+    /* The names the flat layout has handed out, so a second chunk of one name
+    can tell. Behind a mutex because the workers claim names concurrently. */
+    flat_names: Mutex<HashSet<String>>,
 }
 
 /// A filter that matches all paths (no filtering).
@@ -204,6 +348,11 @@ impl<'a, R: PathResolver> WadExtractor<'a, R, NoFilter> {
             filter: None,
             type_filter: None,
             progress_callback: None,
+            layout: ExtractLayout::default(),
+            existing: ExistingFilePolicy::default(),
+            cancel: None,
+            workers: None,
+            flat_names: Mutex::default(),
         }
     }
 }
@@ -218,6 +367,11 @@ impl<'a, R: PathResolver, F: PathFilter> WadExtractor<'a, R, F> {
             filter: Some(filter),
             type_filter: self.type_filter,
             progress_callback: self.progress_callback,
+            layout: self.layout,
+            existing: self.existing,
+            cancel: self.cancel,
+            workers: self.workers,
+            flat_names: self.flat_names,
         }
     }
 
@@ -237,57 +391,112 @@ impl<'a, R: PathResolver, F: PathFilter> WadExtractor<'a, R, F> {
         self
     }
 
-    /// Extract all chunks from a WAD to the specified directory.
+    /// Set where the extracted chunks land.
     ///
-    /// Returns the number of chunks actually extracted (not skipped).
+    /// The default is [`ExtractLayout::Paths`].
+    pub fn with_layout(mut self, layout: ExtractLayout) -> Self {
+        self.layout = layout;
+        self
+    }
+
+    /// Set what happens to a chunk whose file exists already.
+    ///
+    /// The default is [`ExistingFilePolicy::Overwrite`].
+    pub fn with_existing_file_policy(mut self, policy: ExistingFilePolicy) -> Self {
+        self.existing = policy;
+        self
+    }
+
+    /// Stop early once `flag` reads `true`.
+    ///
+    /// The flag is read before each chunk is read from the archive. Chunks
+    /// already handed to a worker still land, and
+    /// [`ExtractReport::cancelled`] reports the stop.
+    pub fn with_cancel_flag(mut self, flag: &'a AtomicBool) -> Self {
+        self.cancel = Some(flag);
+        self
+    }
+
+    /// Set how many threads decompress and write.
+    ///
+    /// The default is the machine's available parallelism, capped at eight.
+    pub fn with_workers(mut self, workers: NonZeroUsize) -> Self {
+        self.workers = Some(workers);
+        self
+    }
+
+    /// Extract every chunk of `wad` into `output_dir`.
+    ///
+    /// # Errors
+    ///
+    /// Fails on the first chunk that cannot be read, decompressed or written.
+    /// Chunks written before it stay on disk.
     pub fn extract_all<TSource: Read + Seek>(
         &self,
         wad: &mut Wad<TSource>,
         output_dir: impl AsRef<Utf8Path>,
-    ) -> Result<usize, WadError> {
-        let output_dir = output_dir.as_ref();
+    ) -> Result<ExtractReport, WadError> {
         let chunks: Vec<WadChunk> = wad.chunks().iter().copied().collect();
-        let total = chunks.len();
-        let mut extracted_count = 0;
+        self.extract_chunks(wad, &chunks, output_dir)
+    }
 
-        for (index, chunk) in chunks.iter().enumerate() {
-            let chunk_path_str = self.resolver.resolve(chunk.path_hash());
-            let chunk_path = Utf8Path::new(chunk_path_str.as_ref());
+    /// Extract `chunks` of `wad` into `output_dir`, in the order given.
+    ///
+    /// A chunk is read at the offsets it carries, so take the chunks from
+    /// [`Wad::chunks`] of the same archive.
+    ///
+    /// # Errors
+    ///
+    /// Fails on the first chunk that cannot be read, decompressed or written.
+    /// Chunks written before it stay on disk.
+    pub fn extract_chunks<TSource: Read + Seek>(
+        &self,
+        wad: &mut Wad<TSource>,
+        chunks: &[WadChunk],
+        output_dir: impl AsRef<Utf8Path>,
+    ) -> Result<ExtractReport, WadError> {
+        let output_dir = output_dir.as_ref();
+        let workers = self.workers.map_or_else(default_workers, NonZeroUsize::get);
 
-            // Report progress
-            if let Some(ref callback) = self.progress_callback {
-                callback(ExtractProgress {
-                    current: index,
-                    total,
-                    current_path: chunk_path_str.as_ref(),
-                    path_hash: chunk.path_hash(),
-                });
+        let shared = Shared {
+            writer: self.writer(output_dir),
+            report: Mutex::default(),
+            failure: Mutex::default(),
+        };
+        let (sender, receiver) = mpsc::sync_channel::<Job>(workers);
+        let receiver = Mutex::new(receiver);
+
+        /* Taken inside the scope so it drops before the workers are joined.
+        A worker only stops once every sender is gone. */
+        let mut sender = Some(sender);
+        let cancelled = thread::scope(|scope| {
+            for _ in 0..workers {
+                scope.spawn(|| shared.run_worker(&receiver));
             }
+            let sender = sender.take().expect("the sender is taken once");
+            self.read_chunks(wad, chunks, &sender, &shared)
+        })?;
 
-            // Check path filter
-            if let Some(ref filter) = self.filter {
-                if !filter.matches(chunk_path_str.as_ref()) {
-                    continue;
-                }
-            }
-
-            // Load and decompress
-            let chunk_data = wad.load_chunk_decompressed(chunk)?;
-
-            // Extract the chunk
-            match self.extract_chunk_data(chunk, &chunk_data, chunk_path, output_dir)? {
-                ExtractResult::Extracted => extracted_count += 1,
-                ExtractResult::SkippedByType | ExtractResult::SkippedByPattern => {}
-            }
+        if let Some(error) = shared
+            .failure
+            .into_inner()
+            .unwrap_or_else(PoisonError::into_inner)
+        {
+            return Err(error);
         }
-
-        Ok(extracted_count)
+        let mut report = shared
+            .report
+            .into_inner()
+            .unwrap_or_else(PoisonError::into_inner);
+        report.cancelled = cancelled;
+        Ok(report)
     }
 
     /// Extract a single chunk from already-decompressed data to the specified directory.
     ///
     /// This is useful for parallel workflows where decompression is done separately
-    /// (e.g. via [`decompress_raw`](crate::decompress_raw)).
+    /// (e.g. via [`decompress_raw`](crate::decompress_raw)). The layout and the
+    /// existing-file policy apply as they do to [`extract_chunks`](Self::extract_chunks).
     pub fn extract_chunk_data(
         &self,
         chunk: &WadChunk,
@@ -295,42 +504,195 @@ impl<'a, R: PathResolver, F: PathFilter> WadExtractor<'a, R, F> {
         chunk_path: &Utf8Path,
         output_dir: &Utf8Path,
     ) -> Result<ExtractResult, WadError> {
-        // Identify the file type
-        let chunk_kind = LeagueFileKind::identify_from_bytes(chunk_data);
+        self.writer(output_dir)
+            .write_chunk(chunk, chunk_data, chunk_path)
+            .map(ExtractResult::from)
+    }
 
-        // Check type filter
-        if let Some(ref type_filter) = self.type_filter {
-            if !type_filter.contains(&chunk_kind) {
-                return Ok(ExtractResult::SkippedByType);
+    fn writer<'s>(&'s self, output_dir: &'s Utf8Path) -> ChunkWriter<'s> {
+        ChunkWriter {
+            layout: self.layout,
+            existing: self.existing,
+            type_filter: self.type_filter.as_deref(),
+            output_dir,
+            flat_names: &self.flat_names,
+        }
+    }
+
+    /// Feed the workers, chunk by chunk, and say whether the cancel flag stopped it.
+    fn read_chunks<TSource: Read + Seek>(
+        &self,
+        wad: &mut Wad<TSource>,
+        chunks: &[WadChunk],
+        sender: &mpsc::SyncSender<Job>,
+        shared: &Shared<'_>,
+    ) -> Result<bool, WadError> {
+        let total = chunks.len();
+        for (index, chunk) in chunks.iter().enumerate() {
+            if self.cancel.is_some_and(|flag| flag.load(Ordering::Relaxed)) {
+                return Ok(true);
+            }
+            if shared.failed() {
+                return Ok(false);
+            }
+
+            let chunk_path = self.resolver.resolve(chunk.path_hash);
+
+            if let Some(callback) = &self.progress_callback {
+                callback(ExtractProgress {
+                    current: index,
+                    total,
+                    current_path: chunk_path.as_ref(),
+                    path_hash: chunk.path_hash,
+                });
+            }
+
+            if let Some(filter) = &self.filter {
+                if !filter.matches(chunk_path.as_ref()) {
+                    lock(&shared.report).skipped_by_filter += 1;
+                    continue;
+                }
+            }
+
+            let raw = wad.load_chunk_raw(chunk)?;
+            let job = Job {
+                chunk: *chunk,
+                path: chunk_path.into_owned(),
+                raw,
+            };
+            /* Refused only once every worker is gone, which takes a panic. */
+            if sender.send(job).is_err() {
+                break;
             }
         }
+        Ok(false)
+    }
+}
 
-        // Determine the final output path
-        let final_path = self.resolve_final_path(chunk_path, output_dir, chunk_data, chunk_kind);
-        let full_path = output_dir.join(&final_path);
+fn default_workers() -> usize {
+    thread::available_parallelism().map_or(1, |count| count.get().min(DEFAULT_WORKER_CAP))
+}
 
-        // Create parent directories
+fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+    mutex.lock().unwrap_or_else(PoisonError::into_inner)
+}
+
+/// One chunk on its way from the reader to a worker.
+struct Job {
+    chunk: WadChunk,
+    path: String,
+    raw: Box<[u8]>,
+}
+
+/// What the workers share: the writer, the tally, and the first failure.
+struct Shared<'s> {
+    writer: ChunkWriter<'s>,
+    report: Mutex<ExtractReport>,
+    failure: Mutex<Option<WadError>>,
+}
+
+impl Shared<'_> {
+    fn failed(&self) -> bool {
+        lock(&self.failure).is_some()
+    }
+
+    /// Take jobs until every sender is gone.
+    ///
+    /// After a failure the jobs are drained and dropped rather than written,
+    /// so a reader blocked on a full channel gets to see the failure too.
+    fn run_worker(&self, receiver: &Mutex<mpsc::Receiver<Job>>) {
+        loop {
+            let Ok(job) = lock(receiver).recv() else {
+                return;
+            };
+            if self.failed() {
+                continue;
+            }
+            match self.writer.write(&job) {
+                Ok(outcome) => lock(&self.report).record(outcome),
+                Err(error) => {
+                    let mut failure = lock(&self.failure);
+                    if failure.is_none() {
+                        *failure = Some(error);
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// The half of the extractor that the workers share.
+///
+/// Everything here is [`Sync`]. The resolver, the path filter and the progress
+/// callback stay behind on the reader, which is what keeps those three free of
+/// any such bound.
+struct ChunkWriter<'s> {
+    layout: ExtractLayout,
+    existing: ExistingFilePolicy,
+    type_filter: Option<&'s [LeagueFileKind]>,
+    output_dir: &'s Utf8Path,
+    flat_names: &'s Mutex<HashSet<String>>,
+}
+
+impl ChunkWriter<'_> {
+    fn write(&self, job: &Job) -> Result<ChunkOutcome, WadError> {
+        let data = decompress_raw(
+            &job.raw,
+            job.chunk.compression_type,
+            job.chunk.uncompressed_size,
+        )?;
+        self.write_chunk(&job.chunk, &data, Utf8Path::new(&job.path))
+    }
+
+    fn write_chunk(
+        &self,
+        chunk: &WadChunk,
+        chunk_data: &[u8],
+        chunk_path: &Utf8Path,
+    ) -> Result<ChunkOutcome, WadError> {
+        let chunk_kind = LeagueFileKind::identify_from_bytes(chunk_data);
+
+        if self
+            .type_filter
+            .is_some_and(|types| !types.contains(&chunk_kind))
+        {
+            return Ok(ChunkOutcome::SkippedByType);
+        }
+
+        let relative_path = match self.layout {
+            ExtractLayout::Paths => self.resolve_final_path(chunk_path, chunk_data, chunk_kind),
+            ExtractLayout::Flat => {
+                self.resolve_flat_path(chunk, chunk_path, chunk_data, chunk_kind)
+            }
+        };
+        let full_path = self.output_dir.join(&relative_path);
+
         if let Some(parent) = full_path.parent() {
             fs::create_dir_all(parent)?;
         }
 
-        // Write the file
-        match fs::write(&full_path, chunk_data) {
-            Ok(()) => Ok(ExtractResult::Extracted),
+        let written = match write_file(&full_path, chunk_data, self.existing) {
+            Ok(written) => written,
             Err(error) if error.kind() == io::ErrorKind::InvalidFilename => {
-                // Fallback for long filenames
-                self.write_with_hashed_name(chunk, chunk_data, chunk_kind, output_dir)?;
-                Ok(ExtractResult::Extracted)
+                let hashed_path = self.output_dir.join(hashed_name(chunk, chunk_kind));
+                write_file(&hashed_path, chunk_data, self.existing)?
             }
-            Err(error) => Err(WadError::IoError(error)),
-        }
+            Err(error) => return Err(WadError::IoError(error)),
+        };
+
+        Ok(match written {
+            Written::Yes => ChunkOutcome::Written {
+                kind: chunk_kind,
+                bytes: chunk_data.len() as u64,
+            },
+            Written::Existed => ChunkOutcome::SkippedExisting,
+        })
     }
 
     /// Resolve the final output path for a chunk.
     fn resolve_final_path(
         &self,
         chunk_path: &Utf8Path,
-        output_dir: &Utf8Path,
         chunk_data: &[u8],
         chunk_kind: LeagueFileKind,
     ) -> Utf8PathBuf {
@@ -347,7 +709,7 @@ impl<'a, R: PathResolver, F: PathFilter> WadExtractor<'a, R, F> {
         // - If the original path has no extension, affix .ltk (and real extension if known)
         // - OR if the destination path collides with an existing directory, affix .ltk
         let has_extension = final_path.extension().is_some();
-        let collides_with_dir = output_dir.join(&final_path).is_dir();
+        let collides_with_dir = self.output_dir.join(&final_path).is_dir();
         if !has_extension || collides_with_dir {
             final_path.set_file_name(build_ltk_name(
                 chunk_path.file_stem().unwrap_or_default(),
@@ -358,22 +720,70 @@ impl<'a, R: PathResolver, F: PathFilter> WadExtractor<'a, R, F> {
         final_path
     }
 
-    /// Write a chunk with a hashed filename (fallback for long filenames).
-    fn write_with_hashed_name(
+    /// The file name alone, made unique among the names this extraction wrote.
+    fn resolve_flat_path(
         &self,
         chunk: &WadChunk,
+        chunk_path: &Utf8Path,
         chunk_data: &[u8],
         chunk_kind: LeagueFileKind,
-        output_dir: &Utf8Path,
-    ) -> Result<(), WadError> {
-        let mut hashed_path = Utf8PathBuf::from(format!("{:016x}", chunk.path_hash()));
-        if let Some(ext) = chunk_kind.extension() {
-            hashed_path.set_extension(ext);
+    ) -> Utf8PathBuf {
+        let file_name = Utf8Path::new(chunk_path.file_name().unwrap_or_default());
+        let named = self.resolve_final_path(file_name, chunk_data, chunk_kind);
+
+        let mut names = lock(self.flat_names);
+        if names.insert(named.as_str().to_owned()) {
+            return named;
         }
 
-        fs::write(output_dir.join(hashed_path), chunk_data)?;
-        Ok(())
+        let suffixed = match named.extension() {
+            Some(ext) => format!(
+                "{}.{:016x}.{ext}",
+                named.file_stem().unwrap_or_default(),
+                chunk.path_hash
+            ),
+            None => format!("{}.{:016x}", named.as_str(), chunk.path_hash),
+        };
+        names.insert(suffixed.clone());
+        Utf8PathBuf::from(suffixed)
     }
+}
+
+enum Written {
+    Yes,
+    Existed,
+}
+
+/// Write `data` to `path` under `policy`.
+///
+/// `Skip` opens with `create_new`, which makes the existence check and the
+/// create one operation, so two workers can never both write one path.
+fn write_file(path: &Utf8Path, data: &[u8], policy: ExistingFilePolicy) -> io::Result<Written> {
+    match policy {
+        ExistingFilePolicy::Overwrite => {
+            fs::write(path, data)?;
+            Ok(Written::Yes)
+        }
+        ExistingFilePolicy::Skip => {
+            match OpenOptions::new().write(true).create_new(true).open(path) {
+                Ok(mut file) => {
+                    file.write_all(data)?;
+                    Ok(Written::Yes)
+                }
+                Err(error) if error.kind() == io::ErrorKind::AlreadyExists => Ok(Written::Existed),
+                Err(error) => Err(error),
+            }
+        }
+    }
+}
+
+/// `<hash>.<ext>`, the name a chunk falls back to when its own is refused.
+fn hashed_name(chunk: &WadChunk, chunk_kind: LeagueFileKind) -> Utf8PathBuf {
+    let mut hashed_path = Utf8PathBuf::from(format!("{:016x}", chunk.path_hash));
+    if let Some(ext) = chunk_kind.extension() {
+        hashed_path.set_extension(ext);
+    }
+    hashed_path
 }
 
 /// Check if a path looks like a hex-encoded hash (e.g., "0123456789abcdef").
@@ -907,9 +1317,9 @@ mod tests {
         let extractor = WadExtractor::new(&resolver);
 
         let mut wad = source.into_wad(chunks);
-        let extracted = extractor.extract_all(&mut wad, output_path).unwrap();
+        let report = extractor.extract_all(&mut wad, output_path).unwrap();
 
-        assert_eq!(extracted, 3);
+        assert_eq!(report.extracted, 3);
 
         // Verify all files were created
         assert!(temp_dir.path().join("dir1/file1.txt").exists());
@@ -946,10 +1356,11 @@ mod tests {
         let extractor = WadExtractor::new(&resolver).with_filter(filter);
 
         let mut wad = source.into_wad(chunks);
-        let extracted = extractor.extract_all(&mut wad, output_path).unwrap();
+        let report = extractor.extract_all(&mut wad, output_path).unwrap();
 
         // Only assets/ file should be extracted
-        assert_eq!(extracted, 1);
+        assert_eq!(report.extracted, 1);
+        assert_eq!(report.skipped_by_filter, 1);
         assert!(temp_dir.path().join("assets/file1.txt").exists());
         assert!(!temp_dir.path().join("data/file2.txt").exists());
     }
@@ -987,10 +1398,11 @@ mod tests {
         let extractor = WadExtractor::new(&resolver).with_type_filter(vec![LeagueFileKind::Png]);
 
         let mut wad = source.into_wad(chunks);
-        let extracted = extractor.extract_all(&mut wad, output_path).unwrap();
+        let report = extractor.extract_all(&mut wad, output_path).unwrap();
 
         // Only PNG file should be extracted
-        assert_eq!(extracted, 1);
+        assert_eq!(report.extracted, 1);
+        assert_eq!(report.skipped_by_filter, 1);
         assert!(temp_dir.path().join("images/test.png").exists());
         assert!(!temp_dir.path().join("text/readme.txt").exists());
     }
@@ -1192,9 +1604,9 @@ mod tests {
         let extractor = WadExtractor::new(&resolver);
 
         let mut wad = source.into_wad(chunks);
-        let extracted = extractor.extract_all(&mut wad, output_path).unwrap();
+        let report = extractor.extract_all(&mut wad, output_path).unwrap();
 
-        assert_eq!(extracted, 0);
+        assert_eq!(report, ExtractReport::default());
     }
 
     #[test]
@@ -1215,6 +1627,221 @@ mod tests {
             });
 
         // Builder compiles and type inference works
+    }
+
+    // =============================================================================
+    // Report, Layout, Policy and Selection Tests
+    // =============================================================================
+
+    const PNG_MAGIC: [u8; 12] = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0, 0, 0, 0];
+
+    /// Three uncompressed text chunks, each under a directory of its own.
+    fn three_file_wad() -> (Wad<MockWadSource>, HashMapPathResolver) {
+        let mut source = MockWadSource::new();
+        let offset1 = source.write_at(1000, b"File one content");
+        let offset2 = source.write_at(2000, b"File two content");
+        let offset3 = source.write_at(3000, b"File three content");
+
+        let chunks = WadChunks::from_iter([
+            create_uncompressed_chunk(0x1111, offset1, b"File one content"),
+            create_uncompressed_chunk(0x2222, offset2, b"File two content"),
+            create_uncompressed_chunk(0x3333, offset3, b"File three content"),
+        ]);
+
+        let mut resolver = HashMapPathResolver::default();
+        resolver.insert(0x1111, "dir1/file1.txt".to_string());
+        resolver.insert(0x2222, "dir2/file2.txt".to_string());
+        resolver.insert(0x3333, "dir3/file3.txt".to_string());
+
+        (source.into_wad(chunks), resolver)
+    }
+
+    #[test]
+    fn extract_all_reports_counts_bytes_and_kinds() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let output_path = Utf8Path::from_path(temp_dir.path()).unwrap();
+
+        let mut source = MockWadSource::new();
+        let text = b"Random text data";
+        let offset1 = source.write_at(1000, &PNG_MAGIC);
+        let offset2 = source.write_at(2000, text);
+        let chunks = WadChunks::from_iter([
+            create_uncompressed_chunk(0x1111, offset1, &PNG_MAGIC),
+            create_uncompressed_chunk(0x2222, offset2, text),
+        ]);
+
+        let mut resolver = HashMapPathResolver::default();
+        resolver.insert(0x1111, "images/test.png".to_string());
+        resolver.insert(0x2222, "text/readme.txt".to_string());
+
+        let mut wad = source.into_wad(chunks);
+        let report = WadExtractor::new(&resolver)
+            .extract_all(&mut wad, output_path)
+            .unwrap();
+
+        assert_eq!(report.extracted, 2);
+        assert_eq!(report.skipped_existing, 0);
+        assert_eq!(report.skipped_by_filter, 0);
+        assert_eq!(report.bytes_written, (PNG_MAGIC.len() + text.len()) as u64);
+        assert_eq!(report.by_kind.get(&LeagueFileKind::Png), Some(&1));
+        assert_eq!(report.by_kind.values().sum::<usize>(), 2);
+        assert!(!report.cancelled);
+    }
+
+    #[test]
+    fn extract_chunks_takes_a_subset() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let output_path = Utf8Path::from_path(temp_dir.path()).unwrap();
+        let (mut wad, resolver) = three_file_wad();
+
+        let wanted = [
+            *wad.chunks().get(0x1111).unwrap(),
+            *wad.chunks().get(0x3333).unwrap(),
+        ];
+        let report = WadExtractor::new(&resolver)
+            .extract_chunks(&mut wad, &wanted, output_path)
+            .unwrap();
+
+        assert_eq!(report.extracted, 2);
+        assert!(temp_dir.path().join("dir1/file1.txt").exists());
+        assert!(!temp_dir.path().join("dir2/file2.txt").exists());
+        assert!(temp_dir.path().join("dir3/file3.txt").exists());
+    }
+
+    #[test]
+    fn flat_layout_drops_the_directories() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let output_path = Utf8Path::from_path(temp_dir.path()).unwrap();
+        let (mut wad, resolver) = three_file_wad();
+
+        let report = WadExtractor::new(&resolver)
+            .with_layout(ExtractLayout::Flat)
+            .extract_all(&mut wad, output_path)
+            .unwrap();
+
+        assert_eq!(report.extracted, 3);
+        assert!(temp_dir.path().join("file1.txt").exists());
+        assert!(temp_dir.path().join("file2.txt").exists());
+        assert!(temp_dir.path().join("file3.txt").exists());
+        assert!(!temp_dir.path().join("dir1").exists());
+    }
+
+    #[test]
+    fn flat_layout_keeps_two_chunks_of_one_name_apart() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let output_path = Utf8Path::from_path(temp_dir.path()).unwrap();
+
+        let mut source = MockWadSource::new();
+        let offset1 = source.write_at(1000, b"first");
+        let offset2 = source.write_at(2000, b"second");
+        let chunks = WadChunks::from_iter([
+            create_uncompressed_chunk(0x1111, offset1, b"first"),
+            create_uncompressed_chunk(0x2222, offset2, b"second"),
+        ]);
+
+        let mut resolver = HashMapPathResolver::default();
+        resolver.insert(0x1111, "a/same.txt".to_string());
+        resolver.insert(0x2222, "b/same.txt".to_string());
+
+        // One worker, so the chunks land in the order they are read.
+        let mut wad = source.into_wad(chunks);
+        let report = WadExtractor::new(&resolver)
+            .with_layout(ExtractLayout::Flat)
+            .with_workers(NonZeroUsize::new(1).unwrap())
+            .extract_all(&mut wad, output_path)
+            .unwrap();
+
+        assert_eq!(report.extracted, 2);
+        assert_eq!(
+            fs::read_to_string(temp_dir.path().join("same.txt")).unwrap(),
+            "first"
+        );
+        assert_eq!(
+            fs::read_to_string(temp_dir.path().join("same.0000000000002222.txt")).unwrap(),
+            "second"
+        );
+    }
+
+    #[test]
+    fn skip_policy_leaves_an_existing_file() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let output_path = Utf8Path::from_path(temp_dir.path()).unwrap();
+        let (mut wad, resolver) = three_file_wad();
+
+        let existing = temp_dir.path().join("dir2/file2.txt");
+        fs::create_dir_all(existing.parent().unwrap()).unwrap();
+        fs::write(&existing, "kept").unwrap();
+
+        let report = WadExtractor::new(&resolver)
+            .with_existing_file_policy(ExistingFilePolicy::Skip)
+            .extract_all(&mut wad, output_path)
+            .unwrap();
+
+        assert_eq!(report.extracted, 2);
+        assert_eq!(report.skipped_existing, 1);
+        assert_eq!(fs::read_to_string(&existing).unwrap(), "kept");
+    }
+
+    #[test]
+    fn overwrite_policy_replaces_an_existing_file() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let output_path = Utf8Path::from_path(temp_dir.path()).unwrap();
+        let (mut wad, resolver) = three_file_wad();
+
+        let existing = temp_dir.path().join("dir2/file2.txt");
+        fs::create_dir_all(existing.parent().unwrap()).unwrap();
+        fs::write(&existing, "old").unwrap();
+
+        let report = WadExtractor::new(&resolver)
+            .extract_all(&mut wad, output_path)
+            .unwrap();
+
+        assert_eq!(report.extracted, 3);
+        assert_eq!(report.skipped_existing, 0);
+        assert_eq!(fs::read_to_string(&existing).unwrap(), "File two content");
+    }
+
+    #[test]
+    fn a_set_cancel_flag_stops_before_the_first_chunk() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let output_path = Utf8Path::from_path(temp_dir.path()).unwrap();
+        let (mut wad, resolver) = three_file_wad();
+
+        let flag = AtomicBool::new(true);
+        let report = WadExtractor::new(&resolver)
+            .with_cancel_flag(&flag)
+            .extract_all(&mut wad, output_path)
+            .unwrap();
+
+        assert!(report.cancelled);
+        assert_eq!(report.extracted, 0);
+        assert!(!temp_dir.path().join("dir1/file1.txt").exists());
+    }
+
+    #[test]
+    fn extract_chunk_data_honors_the_skip_policy() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let output_path = Utf8Path::from_path(temp_dir.path()).unwrap();
+
+        let existing = temp_dir.path().join("test/hello.txt");
+        fs::create_dir_all(existing.parent().unwrap()).unwrap();
+        fs::write(&existing, "kept").unwrap();
+
+        let mut source = MockWadSource::new();
+        let data = b"Hello, World!";
+        let offset = source.write_at(1000, data);
+        let chunk = create_uncompressed_chunk(0x1234, offset, data);
+
+        let resolver = HexPathResolver;
+        let extractor =
+            WadExtractor::new(&resolver).with_existing_file_policy(ExistingFilePolicy::Skip);
+
+        let result = extractor
+            .extract_chunk_data(&chunk, data, Utf8Path::new("test/hello.txt"), output_path)
+            .unwrap();
+
+        assert_eq!(result, ExtractResult::SkippedExisting);
+        assert_eq!(fs::read_to_string(&existing).unwrap(), "kept");
     }
 
     // =============================================================================

--- a/crates/ltk_wad/src/extractor.rs
+++ b/crates/ltk_wad/src/extractor.rs
@@ -78,6 +78,10 @@
 //! - A name the file system refuses as too long falls back to `<hash>.<ext>` in
 //!   the output directory itself.
 //!
+//! A chunk no resolver names can still get its name from the archive itself.
+//! [`WadExtractor::with_name_recovery`] reads the `.bin` files for it first.
+//! Read [`NameRecovery`] for how.
+//!
 //! # Parallelism
 //!
 //! [`extract_all`](WadExtractor::extract_all) and
@@ -104,7 +108,7 @@ use std::{
 use camino::{Utf8Path, Utf8PathBuf};
 use ltk_file::LeagueFileKind;
 
-use crate::{decompress_raw, Wad, WadChunk, WadError};
+use crate::{ChunkDecoder, NameRecovery, RecoveredNames, Wad, WadChunk, WadError};
 
 /// A trait for resolving path hashes to human-readable paths.
 ///
@@ -115,6 +119,15 @@ pub trait PathResolver {
     /// If the hash cannot be resolved, implementations should return the hash
     /// formatted as a hex string (e.g., `format!("{:016x}", path_hash)`).
     fn resolve(&self, path_hash: u64) -> Cow<'_, str>;
+
+    /// Whether the resolver names this hash, rather than falling back to the hex string.
+    ///
+    /// The default reads [`resolve`](Self::resolve) and reports a name that is
+    /// not sixteen hex digits. A resolver that can answer without building the
+    /// string should override it.
+    fn is_known(&self, path_hash: u64) -> bool {
+        !is_hex_chunk_path(Utf8Path::new(self.resolve(path_hash).as_ref()))
+    }
 }
 
 /// A trait for filtering chunks by path pattern.
@@ -134,6 +147,10 @@ pub struct HexPathResolver;
 impl PathResolver for HexPathResolver {
     fn resolve(&self, path_hash: u64) -> Cow<'_, str> {
         Cow::Owned(format!("{:016x}", path_hash))
+    }
+
+    fn is_known(&self, _path_hash: u64) -> bool {
+        false
     }
 }
 
@@ -171,6 +188,10 @@ impl PathResolver for HashMapPathResolver {
             .get(&path_hash)
             .map(|s| Cow::Borrowed(s.as_str()))
             .unwrap_or_else(|| Cow::Owned(format!("{:016x}", path_hash)))
+    }
+
+    fn is_known(&self, path_hash: u64) -> bool {
+        self.paths.contains_key(&path_hash)
     }
 }
 
@@ -268,6 +289,9 @@ pub struct ExtractReport {
     pub by_kind: BTreeMap<LeagueFileKind, usize>,
     /// The cancel flag was set, so some chunks were never read.
     pub cancelled: bool,
+    /// Names that [`with_name_recovery`](WadExtractor::with_name_recovery) read
+    /// out of the archive's bins, by path hash. Empty when recovery was off.
+    pub recovered_names: HashMap<u64, String>,
 }
 
 impl ExtractReport {
@@ -325,6 +349,7 @@ pub struct WadExtractor<'a, R: PathResolver, F: PathFilter = NoFilter> {
     existing: ExistingFilePolicy,
     cancel: Option<&'a AtomicBool>,
     workers: Option<NonZeroUsize>,
+    recover_names: bool,
     /* The names the flat layout has handed out, so a second chunk of one name
     can tell. Behind a mutex because the workers claim names concurrently. */
     flat_names: Mutex<HashSet<String>>,
@@ -352,6 +377,7 @@ impl<'a, R: PathResolver> WadExtractor<'a, R, NoFilter> {
             existing: ExistingFilePolicy::default(),
             cancel: None,
             workers: None,
+            recover_names: false,
             flat_names: Mutex::default(),
         }
     }
@@ -371,6 +397,7 @@ impl<'a, R: PathResolver, F: PathFilter> WadExtractor<'a, R, F> {
             existing: self.existing,
             cancel: self.cancel,
             workers: self.workers,
+            recover_names: self.recover_names,
             flat_names: self.flat_names,
         }
     }
@@ -425,6 +452,17 @@ impl<'a, R: PathResolver, F: PathFilter> WadExtractor<'a, R, F> {
         self
     }
 
+    /// Read the archive's `.bin` files for the names of chunks the resolver
+    /// cannot name, before anything is written.
+    ///
+    /// Read [`NameRecovery`] for what it costs and what it finds. The names
+    /// land in [`ExtractReport::recovered_names`], and the extraction uses the
+    /// same workers and cancel flag for the read.
+    pub fn with_name_recovery(mut self) -> Self {
+        self.recover_names = true;
+        self
+    }
+
     /// Extract every chunk of `wad` into `output_dir`.
     ///
     /// # Errors
@@ -458,6 +496,17 @@ impl<'a, R: PathResolver, F: PathFilter> WadExtractor<'a, R, F> {
         let output_dir = output_dir.as_ref();
         let workers = self.workers.map_or_else(default_workers, NonZeroUsize::get);
 
+        let recovered = if self.recover_names {
+            NameRecovery {
+                workers: self.workers,
+                cancel: self.cancel,
+            }
+            .run(wad, self.resolver)?
+        } else {
+            RecoveredNames::default()
+        };
+        let resolver = recovered.over(self.resolver);
+
         let shared = Shared {
             writer: self.writer(output_dir),
             report: Mutex::default(),
@@ -474,7 +523,7 @@ impl<'a, R: PathResolver, F: PathFilter> WadExtractor<'a, R, F> {
                 scope.spawn(|| shared.run_worker(&receiver));
             }
             let sender = sender.take().expect("the sender is taken once");
-            self.read_chunks(wad, chunks, &sender, &shared)
+            self.read_chunks(wad, chunks, &sender, &shared, &resolver)
         })?;
 
         if let Some(error) = shared
@@ -489,6 +538,7 @@ impl<'a, R: PathResolver, F: PathFilter> WadExtractor<'a, R, F> {
             .into_inner()
             .unwrap_or_else(PoisonError::into_inner);
         report.cancelled = cancelled;
+        report.recovered_names = recovered.names;
         Ok(report)
     }
 
@@ -526,6 +576,7 @@ impl<'a, R: PathResolver, F: PathFilter> WadExtractor<'a, R, F> {
         chunks: &[WadChunk],
         sender: &mpsc::SyncSender<Job>,
         shared: &Shared<'_>,
+        resolver: &impl PathResolver,
     ) -> Result<bool, WadError> {
         let total = chunks.len();
         for (index, chunk) in chunks.iter().enumerate() {
@@ -536,7 +587,7 @@ impl<'a, R: PathResolver, F: PathFilter> WadExtractor<'a, R, F> {
                 return Ok(false);
             }
 
-            let chunk_path = self.resolver.resolve(chunk.path_hash);
+            let chunk_path = resolver.resolve(chunk.path_hash);
 
             if let Some(callback) = &self.progress_callback {
                 callback(ExtractProgress {
@@ -569,11 +620,11 @@ impl<'a, R: PathResolver, F: PathFilter> WadExtractor<'a, R, F> {
     }
 }
 
-fn default_workers() -> usize {
+pub(crate) fn default_workers() -> usize {
     thread::available_parallelism().map_or(1, |count| count.get().min(DEFAULT_WORKER_CAP))
 }
 
-fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+pub(crate) fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
     mutex.lock().unwrap_or_else(PoisonError::into_inner)
 }
 
@@ -601,6 +652,7 @@ impl Shared<'_> {
     /// After a failure the jobs are drained and dropped rather than written,
     /// so a reader blocked on a full channel gets to see the failure too.
     fn run_worker(&self, receiver: &Mutex<mpsc::Receiver<Job>>) {
+        let mut decoder = ChunkDecoder::new();
         loop {
             let Ok(job) = lock(receiver).recv() else {
                 return;
@@ -608,7 +660,7 @@ impl Shared<'_> {
             if self.failed() {
                 continue;
             }
-            match self.writer.write(&job) {
+            match self.writer.write(&job, &mut decoder) {
                 Ok(outcome) => lock(&self.report).record(outcome),
                 Err(error) => {
                     let mut failure = lock(&self.failure);
@@ -635,8 +687,8 @@ struct ChunkWriter<'s> {
 }
 
 impl ChunkWriter<'_> {
-    fn write(&self, job: &Job) -> Result<ChunkOutcome, WadError> {
-        let data = decompress_raw(
+    fn write(&self, job: &Job, decoder: &mut ChunkDecoder) -> Result<ChunkOutcome, WadError> {
+        let data = decoder.decompress(
             &job.raw,
             job.chunk.compression_type,
             job.chunk.uncompressed_size,

--- a/crates/ltk_wad/src/lib.rs
+++ b/crates/ltk_wad/src/lib.rs
@@ -32,8 +32,8 @@
 //! let extractor = WadExtractor::new(&HexPathResolver)
 //!     .on_progress(|p| println!("{:.0}%", p.percent() * 100.0));
 //!
-//! let count = extractor.extract_all(&mut wad, "/output/path")?;
-//! println!("Extracted {count} chunks");
+//! let report = extractor.extract_all(&mut wad, "/output/path")?;
+//! println!("Extracted {} chunks ({} bytes)", report.extracted, report.bytes_written);
 //! # Ok::<(), Box<dyn std::error::Error>>(())
 //! ```
 //!

--- a/crates/ltk_wad/src/lib.rs
+++ b/crates/ltk_wad/src/lib.rs
@@ -24,16 +24,17 @@
 //!
 //! ```no_run
 //! use std::fs::File;
-//! use ltk_wad::{Wad, WadExtractor, HexPathResolver};
+//! use ltk_wad::{Wad, WadExtractor, NoResolver};
 //!
 //! let file = File::open("archive.wad.client")?;
 //! let mut wad = Wad::mount(file)?;
 //!
-//! let extractor = WadExtractor::new(&HexPathResolver)
-//!     .on_progress(|p| println!("{:.0}%", p.percent() * 100.0));
+//! // Any `HashMap<u64, String>` names the chunks. `NoResolver` names none.
+//! let mut extractor = WadExtractor::new(&NoResolver)
+//!     .on_progress(|p| println!("{:.0}%", p.fraction() * 100.0));
 //!
 //! let report = extractor.extract_all(&mut wad, "/output/path")?;
-//! println!("Extracted {} chunks ({} bytes)", report.extracted, report.bytes_written);
+//! println!("{report}");
 //! # Ok::<(), Box<dyn std::error::Error>>(())
 //! ```
 //!
@@ -145,6 +146,8 @@ pub struct Wad<TSource: Read + Seek> {
     checksum: u64,
     #[cfg_attr(feature = "serde", serde(skip))]
     source: TSource,
+    #[cfg_attr(feature = "serde", serde(skip))]
+    decoder: ChunkDecoder,
 }
 
 impl<TSource: Read + Seek> Wad<TSource> {
@@ -208,6 +211,7 @@ impl<TSource: Read + Seek> Wad<TSource> {
             checksum,
             chunks,
             source,
+            decoder: ChunkDecoder::new(),
         })
     }
 
@@ -250,9 +254,13 @@ impl<TSource: Read + Seek> Wad<TSource> {
     }
 
     /// Reads and decompresses a chunk from the source.
+    ///
+    /// The decoder is kept between calls, so a run of chunks pays for one
+    /// zstd context and not one per chunk.
     pub fn load_chunk_decompressed(&mut self, chunk: &WadChunk) -> Result<Box<[u8]>, WadError> {
         let raw_data = self.load_chunk_raw(chunk)?;
-        decompress_raw(&raw_data, chunk.compression_type, chunk.uncompressed_size)
+        self.decoder
+            .decompress(&raw_data, chunk.compression_type, chunk.uncompressed_size)
     }
 
     /// Returns embedded checksum verbatim.

--- a/crates/ltk_wad/src/lib.rs
+++ b/crates/ltk_wad/src/lib.rs
@@ -92,6 +92,7 @@ mod decoder;
 mod error;
 mod extractor;
 mod file_ext;
+mod recovery;
 
 pub use builder::*;
 pub use chunk::*;
@@ -100,6 +101,7 @@ pub use decoder::*;
 pub use error::*;
 pub use extractor::*;
 pub use file_ext::*;
+pub use recovery::*;
 
 use std::io::{BufReader, Read, Seek, SeekFrom};
 
@@ -221,6 +223,24 @@ impl<TSource: Read + Seek> Wad<TSource> {
     /// Reads the raw (compressed) bytes of a chunk from the source.
     pub fn load_chunk_raw(&mut self, chunk: &WadChunk) -> Result<Box<[u8]>, WadError> {
         let mut data = vec![0; chunk.compressed_size];
+
+        self.source
+            .seek(SeekFrom::Start(chunk.data_offset as u64))?;
+        self.source.read_exact(&mut data)?;
+
+        Ok(data.into_boxed_slice())
+    }
+
+    /// Reads at most `max_len` of the raw (compressed) bytes of a chunk, from its start.
+    ///
+    /// Enough of a gzip or zstd stream to decode its first block, which is what
+    /// [`decompress_prefix`] wants to read a chunk's first bytes without the rest.
+    pub fn load_chunk_raw_prefix(
+        &mut self,
+        chunk: &WadChunk,
+        max_len: usize,
+    ) -> Result<Box<[u8]>, WadError> {
+        let mut data = vec![0; chunk.compressed_size.min(max_len)];
 
         self.source
             .seek(SeekFrom::Start(chunk.data_offset as u64))?;

--- a/crates/ltk_wad/src/lib.rs
+++ b/crates/ltk_wad/src/lib.rs
@@ -4,18 +4,19 @@
 //!
 //! ```no_run
 //! use std::fs::File;
-//! use ltk_wad::Wad;
+//! use ltk_hash::Hash as _;
+//! use ltk_wad::{Wad, WadHash};
 //!
 //! let file = File::open("archive.wad.client")?;
 //! let mut wad = Wad::mount(file)?;
 //!
 //! // Iterate chunks in path-hash order
 //! for chunk in wad.chunks() {
-//!     println!("{:#016x} ({} bytes)", chunk.path_hash(), chunk.uncompressed_size());
+//!     println!("{:016x} ({} bytes)", chunk.path_hash(), chunk.uncompressed_size());
 //! }
 //!
 //! // Read and decompress a specific chunk
-//! let chunk = *wad.chunks().get(0x1234567890abcdef).unwrap();
+//! let chunk = *wad.chunks().get(WadHash::hash_str("assets/some/file.dds")).unwrap();
 //! let data = wad.load_chunk_decompressed(&chunk)?;
 //! # Ok::<(), Box<dyn std::error::Error>>(())
 //! ```
@@ -29,7 +30,7 @@
 //! let file = File::open("archive.wad.client")?;
 //! let mut wad = Wad::mount(file)?;
 //!
-//! // Any `HashMap<u64, String>` names the chunks. `NoResolver` names none.
+//! // Any `HashMap<WadHash, String>` names the chunks. `NoResolver` names none.
 //! let mut extractor = WadExtractor::new(&NoResolver)
 //!     .on_progress(|p| println!("{:.0}%", p.fraction() * 100.0));
 //!
@@ -103,6 +104,14 @@ pub use error::*;
 pub use extractor::*;
 pub use file_ext::*;
 pub use recovery::*;
+
+/// A chunk's key: the xxh64 of its lower-case path.
+///
+/// Re-exported from `ltk_hash`, where the bin tooling takes the same type
+/// for a `WadChunkLink`, so a link read out of a bin looks a chunk up as is.
+/// To hash a path, bring `ltk_hash::Hash` into scope and call
+/// `WadHash::hash_str`.
+pub use ltk_hash::WadHash;
 
 use std::io::{BufReader, Read, Seek, SeekFrom};
 

--- a/crates/ltk_wad/src/lib.rs
+++ b/crates/ltk_wad/src/lib.rs
@@ -108,7 +108,7 @@ pub use recovery::*;
 /// A chunk's key: the xxh64 of its lower-case path.
 ///
 /// Re-exported from `ltk_hash`, where the bin tooling takes the same type
-/// for a `WadChunkLink`, so a link read out of a bin looks a chunk up as is.
+/// for a `WadChunkLink`, so a link read out of a bin finds its chunk as is.
 /// To hash a path, bring `ltk_hash::Hash` into scope and call
 /// `WadHash::hash_str`.
 pub use ltk_hash::WadHash;
@@ -246,8 +246,8 @@ impl<TSource: Read + Seek> Wad<TSource> {
 
     /// Reads at most `max_len` of the raw (compressed) bytes of a chunk, from its start.
     ///
-    /// Enough of a gzip or zstd stream to decode its first block, which is what
-    /// [`decompress_prefix`] wants to read a chunk's first bytes without the rest.
+    /// Enough of a gzip or zstd stream decodes its first block, which is all
+    /// [`decompress_prefix`] needs for a chunk's first bytes.
     pub fn load_chunk_raw_prefix(
         &mut self,
         chunk: &WadChunk,
@@ -264,8 +264,8 @@ impl<TSource: Read + Seek> Wad<TSource> {
 
     /// Reads and decompresses a chunk from the source.
     ///
-    /// The decoder is kept between calls, so a run of chunks pays for one
-    /// zstd context and not one per chunk.
+    /// The archive keeps the decoder between calls, so a run of chunks pays for
+    /// one zstd context and not one per chunk.
     pub fn load_chunk_decompressed(&mut self, chunk: &WadChunk) -> Result<Box<[u8]>, WadError> {
         let raw_data = self.load_chunk_raw(chunk)?;
         self.decoder

--- a/crates/ltk_wad/src/recovery.rs
+++ b/crates/ltk_wad/src/recovery.rs
@@ -23,16 +23,17 @@
 //! # Example
 //!
 //! ```no_run
+//! use std::collections::HashMap;
 //! use std::fs::File;
-//! use ltk_wad::{HashMapPathResolver, NameRecovery, Wad, WadExtractor};
+//! use ltk_wad::{NameRecovery, Wad, WadExtractor};
 //!
 //! let mut wad = Wad::mount(File::open("archive.wad.client")?)?;
-//! let resolver = HashMapPathResolver::default();
+//! let names: HashMap<u64, String> = HashMap::new();
 //!
-//! let recovered = NameRecovery::new().run(&mut wad, &resolver)?;
+//! let recovered = NameRecovery::new().run(&mut wad, &names)?;
 //! println!("{} names from {} bins", recovered.len(), recovered.bins_scanned);
 //!
-//! let layered = recovered.over(&resolver);
+//! let layered = recovered.over(&names);
 //! WadExtractor::new(&layered).extract_all(&mut wad, "/output/path")?;
 //! # Ok::<(), Box<dyn std::error::Error>>(())
 //! ```
@@ -40,6 +41,7 @@
 use std::{
     borrow::Cow,
     collections::{HashMap, HashSet},
+    fmt,
     io::{Read, Seek},
     num::NonZeroUsize,
     sync::{
@@ -53,7 +55,7 @@ use ltk_file::LeagueFileKind;
 use xxhash_rust::xxh64::xxh64;
 
 use crate::{
-    extractor::{default_workers, lock},
+    extractor::{default_workers, hex_name, lock},
     ChunkDecoder, PathResolver, Wad, WadChunk, WadError,
 };
 
@@ -86,6 +88,9 @@ pub fn hash_wad_path(path: &str) -> u64 {
 }
 
 /// Names recovered from the `.bin` files of one archive.
+///
+/// It is a [`PathResolver`] over the names it holds, and
+/// [`over`](Self::over) layers it on top of another resolver.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct RecoveredNames {
@@ -114,7 +119,7 @@ impl RecoveredNames {
     }
 
     /// A resolver that answers with a recovered name first and asks `fallback` for the rest.
-    pub fn over<'a, R: PathResolver>(&'a self, fallback: &'a R) -> LayeredResolver<'a, R> {
+    pub fn over<'a>(&'a self, fallback: &'a dyn PathResolver) -> LayeredResolver<'a> {
         LayeredResolver {
             names: self,
             fallback,
@@ -122,25 +127,42 @@ impl RecoveredNames {
     }
 }
 
+impl PathResolver for RecoveredNames {
+    fn resolve(&self, path_hash: u64) -> Option<Cow<'_, str>> {
+        self.get(path_hash).map(Cow::Borrowed)
+    }
+
+    fn is_known(&self, path_hash: u64) -> bool {
+        self.names.contains_key(&path_hash)
+    }
+}
+
 /// Recovered names over another resolver.
 ///
 /// Built by [`RecoveredNames::over`].
-#[derive(Debug)]
-pub struct LayeredResolver<'a, R: PathResolver> {
+pub struct LayeredResolver<'a> {
     names: &'a RecoveredNames,
-    fallback: &'a R,
+    fallback: &'a dyn PathResolver,
 }
 
-impl<R: PathResolver> PathResolver for LayeredResolver<'_, R> {
-    fn resolve(&self, path_hash: u64) -> Cow<'_, str> {
+impl fmt::Debug for LayeredResolver<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("LayeredResolver")
+            .field("names", &self.names)
+            .finish_non_exhaustive()
+    }
+}
+
+impl PathResolver for LayeredResolver<'_> {
+    fn resolve(&self, path_hash: u64) -> Option<Cow<'_, str>> {
         match self.names.get(path_hash) {
-            Some(name) => Cow::Borrowed(name),
+            Some(name) => Some(Cow::Borrowed(name)),
             None => self.fallback.resolve(path_hash),
         }
     }
 
     fn is_known(&self, path_hash: u64) -> bool {
-        self.names.names.contains_key(&path_hash) || self.fallback.is_known(path_hash)
+        self.names.is_known(path_hash) || self.fallback.is_known(path_hash)
     }
 }
 
@@ -177,9 +199,10 @@ impl<'a> NameRecovery<'a> {
     ///
     /// # Errors
     ///
-    /// Fails when the archive cannot be read. A bin that does not decompress
-    /// is skipped, because one bad bin is no reason to lose the names in the rest.
-    pub fn run<S: Read + Seek, R: PathResolver>(
+    /// Fails when the archive cannot be read, with a [`WadError::Chunk`] that
+    /// names the bin. A bin that does not decompress is skipped, because one
+    /// bad bin is no reason to lose the names in the rest.
+    pub fn run<S: Read + Seek, R: PathResolver + ?Sized>(
         &self,
         wad: &mut Wad<S>,
         resolver: &R,
@@ -187,14 +210,17 @@ impl<'a> NameRecovery<'a> {
         let chunks: Vec<WadChunk> = wad.chunks().iter().copied().collect();
 
         let mut unknown = HashSet::new();
-        let mut bins = Vec::new();
+        let mut bins: Vec<(WadChunk, String)> = Vec::new();
         for chunk in &chunks {
-            if resolver.is_known(chunk.path_hash) {
-                if is_bin_name(resolver.resolve(chunk.path_hash).as_ref()) {
-                    bins.push(*chunk);
+            match resolver.resolve(chunk.path_hash) {
+                Some(path) => {
+                    if is_bin_name(&path) {
+                        bins.push((*chunk, path.into_owned()));
+                    }
                 }
-            } else {
-                unknown.insert(chunk.path_hash);
+                None => {
+                    unknown.insert(chunk.path_hash);
+                }
             }
         }
 
@@ -213,7 +239,7 @@ impl<'a> NameRecovery<'a> {
             }
             recovered.chunks_sniffed += 1;
             if sniff_is_bin(wad, chunk, &mut decoder) {
-                bins.push(*chunk);
+                bins.push((*chunk, hex_name(chunk.path_hash)));
             }
         }
         if bins.is_empty() {
@@ -235,11 +261,13 @@ impl<'a> NameRecovery<'a> {
             let sender = sender.take().expect("the sender is taken once");
 
             let mut scanned = 0;
-            for chunk in &bins {
+            for (chunk, path) in &bins {
                 if self.cancelled() || lock(&found).len() == unknown.len() {
                     break;
                 }
-                let raw = wad.load_chunk_raw(chunk)?;
+                let raw = wad
+                    .load_chunk_raw(chunk)
+                    .map_err(|error| WadError::chunk(chunk.path_hash, path, error))?;
                 scanned += 1;
                 if sender.send((*chunk, raw)).is_err() {
                     break;
@@ -374,10 +402,7 @@ mod tests {
     use camino::Utf8Path;
 
     use super::*;
-    use crate::{
-        ExtractLayout, HashMapPathResolver, HexPathResolver, WadBuilder, WadChunkBuilder,
-        WadExtractor,
-    };
+    use crate::{ExtractLayout, NoResolver, WadBuilder, WadChunkBuilder, WadExtractor};
 
     fn collect_candidates(data: &[u8]) -> Vec<String> {
         let mut out = Vec::new();
@@ -385,6 +410,14 @@ mod tests {
             out.push(String::from_utf8_lossy(candidate).into_owned());
         });
         out
+    }
+
+    /// A resolver that names the given paths, by their WAD hashes.
+    fn names(paths: &[&str]) -> HashMap<u64, String> {
+        paths
+            .iter()
+            .map(|path| (hash_wad_path(path), (*path).to_owned()))
+            .collect()
     }
 
     /// A string as a bin writes it: a little-endian `u16` length and the bytes.
@@ -461,9 +494,7 @@ mod tests {
             ("data/test.bin", bin_with(&["assets/a.dds"])),
             ("assets/a.dds", vec![0xab; 16]),
         ]);
-        let mut resolver = HashMapPathResolver::default();
-        resolver.insert(hash_wad_path("data/test.bin"), "data/test.bin".into());
-        resolver.insert(hash_wad_path("assets/a.dds"), "assets/a.dds".into());
+        let resolver = names(&["data/test.bin", "assets/a.dds"]);
 
         let recovered = NameRecovery::new().run(&mut wad, &resolver).unwrap();
 
@@ -477,8 +508,7 @@ mod tests {
             ("data/test.bin", bin_with(&[asset])),
             (asset, vec![0xab; 32]),
         ]);
-        let mut resolver = HashMapPathResolver::default();
-        resolver.insert(hash_wad_path("data/test.bin"), "data/test.bin".into());
+        let resolver = names(&["data/test.bin"]);
 
         let recovered = NameRecovery::new().run(&mut wad, &resolver).unwrap();
 
@@ -500,7 +530,7 @@ mod tests {
             (asset, vec![0xee; 16]),
         ]);
 
-        let recovered = NameRecovery::new().run(&mut wad, &HexPathResolver).unwrap();
+        let recovered = NameRecovery::new().run(&mut wad, &NoResolver).unwrap();
 
         assert_eq!(recovered.get(hash_wad_path(asset)), Some(asset));
         assert_eq!(recovered.chunks_sniffed, 2);
@@ -517,7 +547,7 @@ mod tests {
 
         let recovered = NameRecovery::new()
             .with_cancel_flag(&flag)
-            .run(&mut wad, &HexPathResolver)
+            .run(&mut wad, &NoResolver)
             .unwrap();
 
         assert!(recovered.is_empty());
@@ -528,14 +558,20 @@ mod tests {
     fn the_layered_resolver_reads_recovered_names_first() {
         let mut recovered = RecoveredNames::default();
         recovered.names.insert(0x1234, "assets/found.dds".into());
-        let mut fallback = HashMapPathResolver::default();
+        let mut fallback: HashMap<u64, String> = HashMap::new();
         fallback.insert(0x5678, "assets/known.dds".into());
+
+        assert_eq!(
+            recovered.resolve(0x1234).as_deref(),
+            Some("assets/found.dds")
+        );
+        assert_eq!(recovered.resolve(0x5678), None);
 
         let layered = recovered.over(&fallback);
 
-        assert_eq!(layered.resolve(0x1234), "assets/found.dds");
-        assert_eq!(layered.resolve(0x5678), "assets/known.dds");
-        assert_eq!(layered.resolve(0x9abc), "0000000000009abc");
+        assert_eq!(layered.resolve(0x1234).as_deref(), Some("assets/found.dds"));
+        assert_eq!(layered.resolve(0x5678).as_deref(), Some("assets/known.dds"));
+        assert_eq!(layered.resolve(0x9abc), None);
         assert!(layered.is_known(0x1234));
         assert!(layered.is_known(0x5678));
         assert!(!layered.is_known(0x9abc));
@@ -551,8 +587,7 @@ mod tests {
             ("data/test.bin", bin_with(&[asset])),
             (asset, vec![0xab; 32]),
         ]);
-        let mut resolver = HashMapPathResolver::default();
-        resolver.insert(hash_wad_path("data/test.bin"), "data/test.bin".into());
+        let resolver = names(&["data/test.bin"]);
 
         let report = WadExtractor::new(&resolver)
             .with_name_recovery()
@@ -561,7 +596,8 @@ mod tests {
             .unwrap();
 
         assert_eq!(report.extracted, 2);
-        assert_eq!(report.recovered_names.len(), 1);
+        assert_eq!(report.recovered.len(), 1);
+        assert_eq!(report.recovered.bins_scanned, 1);
         assert!(temp_dir.path().join(asset).exists());
         assert!(temp_dir.path().join("data/test.bin").exists());
     }

--- a/crates/ltk_wad/src/recovery.rs
+++ b/crates/ltk_wad/src/recovery.rs
@@ -25,10 +25,10 @@
 //! ```no_run
 //! use std::collections::HashMap;
 //! use std::fs::File;
-//! use ltk_wad::{NameRecovery, Wad, WadExtractor};
+//! use ltk_wad::{NameRecovery, Wad, WadExtractor, WadHash};
 //!
 //! let mut wad = Wad::mount(File::open("archive.wad.client")?)?;
-//! let names: HashMap<u64, String> = HashMap::new();
+//! let names: HashMap<WadHash, String> = HashMap::new();
 //!
 //! let recovered = NameRecovery::new().run(&mut wad, &names)?;
 //! println!("{} names from {} bins", recovered.len(), recovered.bins_scanned);
@@ -52,7 +52,7 @@ use std::{
 };
 
 use ltk_file::LeagueFileKind;
-use xxhash_rust::xxh64::xxh64;
+use ltk_hash::{Hash as _, WadHash};
 
 use crate::{
     extractor::{default_workers, hex_name, lock},
@@ -82,11 +82,6 @@ const MIN_CANDIDATE_LEN: usize = 4;
 /// A chunk and its raw bytes, on the way from the reader to a worker.
 type RawChunk = (WadChunk, Box<[u8]>);
 
-/// The WAD path hash of `path`: xxh64 of the path in lower case, with seed 0.
-pub fn hash_wad_path(path: &str) -> u64 {
-    xxh64(path.to_lowercase().as_bytes(), 0)
-}
-
 /// Names recovered from the `.bin` files of one archive.
 ///
 /// It is a [`PathResolver`] over the names it holds, and
@@ -95,7 +90,7 @@ pub fn hash_wad_path(path: &str) -> u64 {
 #[non_exhaustive]
 pub struct RecoveredNames {
     /// Path hash to the path a bin named it by, for chunks the resolver could not name.
-    pub names: HashMap<u64, String>,
+    pub names: HashMap<WadHash, String>,
     /// Bins read for the names.
     pub bins_scanned: usize,
     /// Chunks whose first bytes were read because nothing named them.
@@ -104,7 +99,7 @@ pub struct RecoveredNames {
 
 impl RecoveredNames {
     /// The recovered path of a chunk, if a bin named it.
-    pub fn get(&self, path_hash: u64) -> Option<&str> {
+    pub fn get(&self, path_hash: WadHash) -> Option<&str> {
         self.names.get(&path_hash).map(String::as_str)
     }
 
@@ -128,11 +123,11 @@ impl RecoveredNames {
 }
 
 impl PathResolver for RecoveredNames {
-    fn resolve(&self, path_hash: u64) -> Option<Cow<'_, str>> {
+    fn resolve(&self, path_hash: WadHash) -> Option<Cow<'_, str>> {
         self.get(path_hash).map(Cow::Borrowed)
     }
 
-    fn is_known(&self, path_hash: u64) -> bool {
+    fn is_known(&self, path_hash: WadHash) -> bool {
         self.names.contains_key(&path_hash)
     }
 }
@@ -154,14 +149,14 @@ impl fmt::Debug for LayeredResolver<'_> {
 }
 
 impl PathResolver for LayeredResolver<'_> {
-    fn resolve(&self, path_hash: u64) -> Option<Cow<'_, str>> {
+    fn resolve(&self, path_hash: WadHash) -> Option<Cow<'_, str>> {
         match self.names.get(path_hash) {
             Some(name) => Some(Cow::Borrowed(name)),
             None => self.fallback.resolve(path_hash),
         }
     }
 
-    fn is_known(&self, path_hash: u64) -> bool {
+    fn is_known(&self, path_hash: WadHash) -> bool {
         self.names.is_known(path_hash) || self.fallback.is_known(path_hash)
     }
 }
@@ -289,10 +284,9 @@ impl<'a> NameRecovery<'a> {
 /// Decompress each bin and claim every string in it that names an unknown chunk.
 fn scan_bins(
     receiver: &Mutex<mpsc::Receiver<RawChunk>>,
-    unknown: &HashSet<u64>,
-    found: &Mutex<HashMap<u64, String>>,
+    unknown: &HashSet<WadHash>,
+    found: &Mutex<HashMap<WadHash, String>>,
 ) {
-    let mut lower = Vec::new();
     let mut decoder = ChunkDecoder::new();
     loop {
         let Ok((chunk, raw)) = lock(receiver).recv() else {
@@ -308,11 +302,11 @@ fn scan_bins(
         }
 
         for_each_candidate(&data, |candidate| {
-            let hash = hash_lower(candidate, &mut lower);
+            let hash = WadHash::hash_str(candidate);
             if unknown.contains(&hash) {
                 lock(found)
                     .entry(hash)
-                    .or_insert_with(|| String::from_utf8_lossy(candidate).into_owned());
+                    .or_insert_with(|| candidate.to_owned());
             }
         });
     }
@@ -356,7 +350,7 @@ fn is_printable(byte: u8) -> bool {
     (0x20..=0x7e).contains(&byte)
 }
 
-/// Visit every string a bin holds, as the bytes between its length prefix and its end.
+/// Visit every string a bin holds, as the text between its length prefix and its end.
 ///
 /// The format writes a string as a little-endian `u16` length and the bytes,
 /// with no terminator. A path is printable ASCII and its length's high byte is
@@ -364,7 +358,7 @@ fn is_printable(byte: u8) -> bool {
 /// the two bytes in front of the run are its length. The length then bounds
 /// the string exactly, however many printable bytes follow it, such as the low
 /// byte of the next string's length.
-fn for_each_candidate(data: &[u8], mut visit: impl FnMut(&[u8])) {
+fn for_each_candidate(data: &[u8], mut visit: impl FnMut(&str)) {
     let mut start = 0;
     while start < data.len() {
         if !is_printable(data[start]) {
@@ -381,18 +375,15 @@ fn for_each_candidate(data: &[u8], mut visit: impl FnMut(&[u8])) {
             if len >= MIN_CANDIDATE_LEN && start + len <= end {
                 let candidate = &data[start..start + len];
                 if candidate.iter().any(|&byte| byte == b'/' || byte == b'.') {
-                    visit(candidate);
+                    /* Printable ASCII, so this cannot fail. */
+                    if let Ok(candidate) = std::str::from_utf8(candidate) {
+                        visit(candidate);
+                    }
                 }
             }
         }
         start = end;
     }
-}
-
-fn hash_lower(bytes: &[u8], buffer: &mut Vec<u8>) -> u64 {
-    buffer.clear();
-    buffer.extend(bytes.iter().map(u8::to_ascii_lowercase));
-    xxh64(buffer, 0)
 }
 
 #[cfg(test)]
@@ -406,17 +397,15 @@ mod tests {
 
     fn collect_candidates(data: &[u8]) -> Vec<String> {
         let mut out = Vec::new();
-        for_each_candidate(data, |candidate| {
-            out.push(String::from_utf8_lossy(candidate).into_owned());
-        });
+        for_each_candidate(data, |candidate| out.push(candidate.to_owned()));
         out
     }
 
     /// A resolver that names the given paths, by their WAD hashes.
-    fn names(paths: &[&str]) -> HashMap<u64, String> {
+    fn names(paths: &[&str]) -> HashMap<WadHash, String> {
         paths
             .iter()
-            .map(|path| (hash_wad_path(path), (*path).to_owned()))
+            .map(|path| (WadHash::hash_str(path), (*path).to_owned()))
             .collect()
     }
 
@@ -450,7 +439,7 @@ mod tests {
             .build_to_writer(&mut buffer, |path_hash, cursor| {
                 let (_, bytes) = chunks
                     .iter()
-                    .find(|(path, _)| hash_wad_path(path) == path_hash)
+                    .find(|(path, _)| WadHash::hash_str(path) == path_hash)
                     .expect("every hash is one of the chunks");
                 cursor.write_all(bytes)?;
                 Ok(())
@@ -458,12 +447,6 @@ mod tests {
             .unwrap();
         buffer.set_position(0);
         Wad::mount(buffer).unwrap()
-    }
-
-    #[test]
-    fn hash_wad_path_is_xxh64_of_the_lower_case_path() {
-        assert_eq!(hash_wad_path("ASSETS/X.dds"), xxh64(b"assets/x.dds", 0));
-        assert_eq!(hash_wad_path("assets/x.dds"), xxh64(b"assets/x.dds", 0));
     }
 
     #[test]
@@ -512,14 +495,14 @@ mod tests {
 
         let recovered = NameRecovery::new().run(&mut wad, &resolver).unwrap();
 
-        assert_eq!(recovered.get(hash_wad_path(asset)), Some(asset));
+        assert_eq!(recovered.get(WadHash::hash_str(asset)), Some(asset));
         assert_eq!(recovered.len(), 1);
         assert_eq!(recovered.bins_scanned, 1);
         /* The asset was sniffed, and the named bin was not. */
         assert_eq!(recovered.chunks_sniffed, 1);
         assert!(!recovered
             .names
-            .contains_key(&hash_wad_path("data/test.bin")));
+            .contains_key(&WadHash::hash_str("data/test.bin")));
     }
 
     #[test]
@@ -532,7 +515,7 @@ mod tests {
 
         let recovered = NameRecovery::new().run(&mut wad, &NoResolver).unwrap();
 
-        assert_eq!(recovered.get(hash_wad_path(asset)), Some(asset));
+        assert_eq!(recovered.get(WadHash::hash_str(asset)), Some(asset));
         assert_eq!(recovered.chunks_sniffed, 2);
         assert_eq!(recovered.bins_scanned, 1);
     }
@@ -556,25 +539,26 @@ mod tests {
 
     #[test]
     fn the_layered_resolver_reads_recovered_names_first() {
+        let (found, known, neither) = (WadHash(0x1234), WadHash(0x5678), WadHash(0x9abc));
         let mut recovered = RecoveredNames::default();
-        recovered.names.insert(0x1234, "assets/found.dds".into());
-        let mut fallback: HashMap<u64, String> = HashMap::new();
-        fallback.insert(0x5678, "assets/known.dds".into());
+        recovered.names.insert(found, "assets/found.dds".into());
+        let mut fallback: HashMap<WadHash, String> = HashMap::new();
+        fallback.insert(known, "assets/known.dds".into());
 
         assert_eq!(
-            recovered.resolve(0x1234).as_deref(),
+            recovered.resolve(found).as_deref(),
             Some("assets/found.dds")
         );
-        assert_eq!(recovered.resolve(0x5678), None);
+        assert_eq!(recovered.resolve(known), None);
 
         let layered = recovered.over(&fallback);
 
-        assert_eq!(layered.resolve(0x1234).as_deref(), Some("assets/found.dds"));
-        assert_eq!(layered.resolve(0x5678).as_deref(), Some("assets/known.dds"));
-        assert_eq!(layered.resolve(0x9abc), None);
-        assert!(layered.is_known(0x1234));
-        assert!(layered.is_known(0x5678));
-        assert!(!layered.is_known(0x9abc));
+        assert_eq!(layered.resolve(found).as_deref(), Some("assets/found.dds"));
+        assert_eq!(layered.resolve(known).as_deref(), Some("assets/known.dds"));
+        assert_eq!(layered.resolve(neither), None);
+        assert!(layered.is_known(found));
+        assert!(layered.is_known(known));
+        assert!(!layered.is_known(neither));
     }
 
     #[test]

--- a/crates/ltk_wad/src/recovery.rs
+++ b/crates/ltk_wad/src/recovery.rs
@@ -1,0 +1,568 @@
+//! Recovering chunk names from the `.bin` files of an archive.
+//!
+//! A WAD keys a chunk by the hash of its path and stores no path. A hash table
+//! names most chunks, and the rest extract as sixteen hex digits. League's
+//! `.bin` files name the assets they use by path, as linked files and as string
+//! properties, so the paths of many anonymous chunks sit inside the archive
+//! itself. This module reads them out.
+//!
+//! A match is exact: a string counts only when its hash is the hash of a chunk
+//! the resolver could not name, so a string that is not a path never matches.
+//!
+//! # How it stays cheap
+//!
+//! - Nothing runs when the resolver names every chunk.
+//! - A bin is found by its name, or by its first bytes. The first bytes come
+//!   from the first compressed block alone, so an anonymous texture costs one
+//!   block and not the whole chunk.
+//! - Strings are read out of the bytes as the length-prefixed runs the format
+//!   writes them as, with no parse of the object tree in between.
+//! - The bins decompress on worker threads, and the scan stops as soon as every
+//!   anonymous chunk has a name.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use std::fs::File;
+//! use ltk_wad::{HashMapPathResolver, NameRecovery, Wad, WadExtractor};
+//!
+//! let mut wad = Wad::mount(File::open("archive.wad.client")?)?;
+//! let resolver = HashMapPathResolver::default();
+//!
+//! let recovered = NameRecovery::new().run(&mut wad, &resolver)?;
+//! println!("{} names from {} bins", recovered.len(), recovered.bins_scanned);
+//!
+//! let layered = recovered.over(&resolver);
+//! WadExtractor::new(&layered).extract_all(&mut wad, "/output/path")?;
+//! # Ok::<(), Box<dyn std::error::Error>>(())
+//! ```
+
+use std::{
+    borrow::Cow,
+    collections::{HashMap, HashSet},
+    io::{Read, Seek},
+    num::NonZeroUsize,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        mpsc, Mutex, PoisonError,
+    },
+    thread,
+};
+
+use ltk_file::LeagueFileKind;
+use xxhash_rust::xxh64::xxh64;
+
+use crate::{
+    extractor::{default_workers, lock},
+    ChunkDecoder, PathResolver, Wad, WadChunk, WadError,
+};
+
+/// Raw bytes the sniff reads from a chunk first.
+///
+/// The first block of nearly every chunk fits, and a chunk whose block does not
+/// gets a second read of [`SNIFF_RAW_BYTES`].
+const SNIFF_FIRST_BYTES: usize = 16 * 1024;
+
+/// Most raw bytes the sniff reads from one chunk.
+///
+/// A zstd block decodes to at most 128 KiB and an incompressible block is no
+/// larger than that, so this always holds the first block and its headers.
+const SNIFF_RAW_BYTES: usize = 256 * 1024;
+
+/// Decoded bytes the sniff needs to tell a bin from anything else.
+///
+/// [`LeagueFileKind::identify_from_bytes`] reads eight at most.
+const SNIFF_BYTES: usize = 8;
+
+/// Shortest printable run worth a hash. No chunk path is shorter.
+const MIN_CANDIDATE_LEN: usize = 4;
+
+/// A chunk and its raw bytes, on the way from the reader to a worker.
+type RawChunk = (WadChunk, Box<[u8]>);
+
+/// The WAD path hash of `path`: xxh64 of the path in lower case, with seed 0.
+pub fn hash_wad_path(path: &str) -> u64 {
+    xxh64(path.to_lowercase().as_bytes(), 0)
+}
+
+/// Names recovered from the `.bin` files of one archive.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct RecoveredNames {
+    /// Path hash to the path a bin named it by, for chunks the resolver could not name.
+    pub names: HashMap<u64, String>,
+    /// Bins read for the names.
+    pub bins_scanned: usize,
+    /// Chunks whose first bytes were read because nothing named them.
+    pub chunks_sniffed: usize,
+}
+
+impl RecoveredNames {
+    /// The recovered path of a chunk, if a bin named it.
+    pub fn get(&self, path_hash: u64) -> Option<&str> {
+        self.names.get(&path_hash).map(String::as_str)
+    }
+
+    /// How many chunks gained a name.
+    pub fn len(&self) -> usize {
+        self.names.len()
+    }
+
+    /// Whether no chunk gained a name.
+    pub fn is_empty(&self) -> bool {
+        self.names.is_empty()
+    }
+
+    /// A resolver that answers with a recovered name first and asks `fallback` for the rest.
+    pub fn over<'a, R: PathResolver>(&'a self, fallback: &'a R) -> LayeredResolver<'a, R> {
+        LayeredResolver {
+            names: self,
+            fallback,
+        }
+    }
+}
+
+/// Recovered names over another resolver.
+///
+/// Built by [`RecoveredNames::over`].
+#[derive(Debug)]
+pub struct LayeredResolver<'a, R: PathResolver> {
+    names: &'a RecoveredNames,
+    fallback: &'a R,
+}
+
+impl<R: PathResolver> PathResolver for LayeredResolver<'_, R> {
+    fn resolve(&self, path_hash: u64) -> Cow<'_, str> {
+        match self.names.get(path_hash) {
+            Some(name) => Cow::Borrowed(name),
+            None => self.fallback.resolve(path_hash),
+        }
+    }
+
+    fn is_known(&self, path_hash: u64) -> bool {
+        self.names.names.contains_key(&path_hash) || self.fallback.is_known(path_hash)
+    }
+}
+
+/// Configuration and execution of a name recovery over one archive.
+#[derive(Debug, Clone, Default)]
+pub struct NameRecovery<'a> {
+    pub(crate) workers: Option<NonZeroUsize>,
+    pub(crate) cancel: Option<&'a AtomicBool>,
+}
+
+impl<'a> NameRecovery<'a> {
+    /// A recovery with the default worker count and no cancel flag.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set how many threads decompress and scan the bins.
+    ///
+    /// The default is the machine's available parallelism, capped at eight.
+    pub fn with_workers(mut self, workers: NonZeroUsize) -> Self {
+        self.workers = Some(workers);
+        self
+    }
+
+    /// Stop early once `flag` reads `true`.
+    ///
+    /// The names found so far are returned, and a stop is not an error.
+    pub fn with_cancel_flag(mut self, flag: &'a AtomicBool) -> Self {
+        self.cancel = Some(flag);
+        self
+    }
+
+    /// Recover names for the chunks of `wad` that `resolver` cannot name.
+    ///
+    /// # Errors
+    ///
+    /// Fails when the archive cannot be read. A bin that does not decompress
+    /// is skipped, because one bad bin is no reason to lose the names in the rest.
+    pub fn run<S: Read + Seek, R: PathResolver>(
+        &self,
+        wad: &mut Wad<S>,
+        resolver: &R,
+    ) -> Result<RecoveredNames, WadError> {
+        let chunks: Vec<WadChunk> = wad.chunks().iter().copied().collect();
+
+        let mut unknown = HashSet::new();
+        let mut bins = Vec::new();
+        for chunk in &chunks {
+            if resolver.is_known(chunk.path_hash) {
+                if is_bin_name(resolver.resolve(chunk.path_hash).as_ref()) {
+                    bins.push(*chunk);
+                }
+            } else {
+                unknown.insert(chunk.path_hash);
+            }
+        }
+
+        let mut recovered = RecoveredNames::default();
+        if unknown.is_empty() {
+            return Ok(recovered);
+        }
+
+        let mut decoder = ChunkDecoder::new();
+        for chunk in &chunks {
+            if !unknown.contains(&chunk.path_hash) {
+                continue;
+            }
+            if self.cancelled() {
+                return Ok(recovered);
+            }
+            recovered.chunks_sniffed += 1;
+            if sniff_is_bin(wad, chunk, &mut decoder) {
+                bins.push(*chunk);
+            }
+        }
+        if bins.is_empty() {
+            return Ok(recovered);
+        }
+
+        let found = Mutex::new(HashMap::new());
+        let workers = self.workers.map_or_else(default_workers, NonZeroUsize::get);
+        let (sender, receiver) = mpsc::sync_channel::<RawChunk>(workers);
+        let receiver = Mutex::new(receiver);
+
+        /* Taken inside the scope so it drops before the workers are joined.
+        A worker only stops once every sender is gone. */
+        let mut sender = Some(sender);
+        let scanned = thread::scope(|scope| {
+            for _ in 0..workers {
+                scope.spawn(|| scan_bins(&receiver, &unknown, &found));
+            }
+            let sender = sender.take().expect("the sender is taken once");
+
+            let mut scanned = 0;
+            for chunk in &bins {
+                if self.cancelled() || lock(&found).len() == unknown.len() {
+                    break;
+                }
+                let raw = wad.load_chunk_raw(chunk)?;
+                scanned += 1;
+                if sender.send((*chunk, raw)).is_err() {
+                    break;
+                }
+            }
+            Ok::<usize, WadError>(scanned)
+        })?;
+
+        recovered.bins_scanned = scanned;
+        recovered.names = found.into_inner().unwrap_or_else(PoisonError::into_inner);
+        Ok(recovered)
+    }
+
+    fn cancelled(&self) -> bool {
+        self.cancel.is_some_and(|flag| flag.load(Ordering::Relaxed))
+    }
+}
+
+/// Decompress each bin and claim every string in it that names an unknown chunk.
+fn scan_bins(
+    receiver: &Mutex<mpsc::Receiver<RawChunk>>,
+    unknown: &HashSet<u64>,
+    found: &Mutex<HashMap<u64, String>>,
+) {
+    let mut lower = Vec::new();
+    let mut decoder = ChunkDecoder::new();
+    loop {
+        let Ok((chunk, raw)) = lock(receiver).recv() else {
+            return;
+        };
+        let Ok(data) = decoder.decompress(&raw, chunk.compression_type, chunk.uncompressed_size)
+        else {
+            continue;
+        };
+        /* A chunk named `.bin` by a hash table is not always one. */
+        if !is_bin_magic(&data) {
+            continue;
+        }
+
+        for_each_candidate(&data, |candidate| {
+            let hash = hash_lower(candidate, &mut lower);
+            if unknown.contains(&hash) {
+                lock(found)
+                    .entry(hash)
+                    .or_insert_with(|| String::from_utf8_lossy(candidate).into_owned());
+            }
+        });
+    }
+}
+
+/// Whether a chunk's first bytes are a bin's, from as little of it as decodes them.
+fn sniff_is_bin<S: Read + Seek>(
+    wad: &mut Wad<S>,
+    chunk: &WadChunk,
+    decoder: &mut ChunkDecoder,
+) -> bool {
+    let wanted = SNIFF_BYTES.min(chunk.uncompressed_size);
+    let mut limit = SNIFF_FIRST_BYTES;
+    loop {
+        let Ok(raw) = wad.load_chunk_raw_prefix(chunk, limit) else {
+            return false;
+        };
+        match decoder.decompress_prefix(&raw, chunk.compression_type, SNIFF_BYTES) {
+            Ok(head) if head.len() >= wanted => return is_bin_magic(&head),
+            /* The first block was cut short, and the chunk holds more. */
+            _ if raw.len() == limit && limit < SNIFF_RAW_BYTES => limit = SNIFF_RAW_BYTES,
+            _ => return false,
+        }
+    }
+}
+
+fn is_bin_magic(data: &[u8]) -> bool {
+    matches!(
+        LeagueFileKind::identify_from_bytes(data),
+        LeagueFileKind::PropertyBin | LeagueFileKind::PropertyBinOverride
+    )
+}
+
+fn is_bin_name(path: &str) -> bool {
+    path.len() > 4
+        && path.is_char_boundary(path.len() - 4)
+        && path[path.len() - 4..].eq_ignore_ascii_case(".bin")
+}
+
+fn is_printable(byte: u8) -> bool {
+    (0x20..=0x7e).contains(&byte)
+}
+
+/// Visit every string a bin holds, as the bytes between its length prefix and its end.
+///
+/// The format writes a string as a little-endian `u16` length and the bytes,
+/// with no terminator. A path is printable ASCII and its length's high byte is
+/// zero, so each run of printable bytes starts on a string's first byte, and
+/// the two bytes in front of the run are its length. The length then bounds
+/// the string exactly, however many printable bytes follow it, such as the low
+/// byte of the next string's length.
+fn for_each_candidate(data: &[u8], mut visit: impl FnMut(&[u8])) {
+    let mut start = 0;
+    while start < data.len() {
+        if !is_printable(data[start]) {
+            start += 1;
+            continue;
+        }
+        let mut end = start;
+        while end < data.len() && is_printable(data[end]) {
+            end += 1;
+        }
+
+        if start >= 2 && end - start >= MIN_CANDIDATE_LEN {
+            let len = usize::from(u16::from_le_bytes([data[start - 2], data[start - 1]]));
+            if len >= MIN_CANDIDATE_LEN && start + len <= end {
+                let candidate = &data[start..start + len];
+                if candidate.iter().any(|&byte| byte == b'/' || byte == b'.') {
+                    visit(candidate);
+                }
+            }
+        }
+        start = end;
+    }
+}
+
+fn hash_lower(bytes: &[u8], buffer: &mut Vec<u8>) -> u64 {
+    buffer.clear();
+    buffer.extend(bytes.iter().map(u8::to_ascii_lowercase));
+    xxh64(buffer, 0)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{Cursor, Write as _};
+
+    use camino::Utf8Path;
+
+    use super::*;
+    use crate::{
+        ExtractLayout, HashMapPathResolver, HexPathResolver, WadBuilder, WadChunkBuilder,
+        WadExtractor,
+    };
+
+    fn collect_candidates(data: &[u8]) -> Vec<String> {
+        let mut out = Vec::new();
+        for_each_candidate(data, |candidate| {
+            out.push(String::from_utf8_lossy(candidate).into_owned());
+        });
+        out
+    }
+
+    /// A string as a bin writes it: a little-endian `u16` length and the bytes.
+    fn bin_string(out: &mut Vec<u8>, text: &str) {
+        out.extend_from_slice(&(text.len() as u16).to_le_bytes());
+        out.extend_from_slice(text.as_bytes());
+    }
+
+    /// Enough of a bin to carry the magic and a few strings. The scan parses
+    /// no structure, so the header is the magic, a version, and the strings.
+    fn bin_with(paths: &[&str]) -> Vec<u8> {
+        let mut out = b"PROP".to_vec();
+        out.extend_from_slice(&2u32.to_le_bytes());
+        out.extend_from_slice(&(paths.len() as u32).to_le_bytes());
+        for path in paths {
+            bin_string(&mut out, path);
+        }
+        out.extend_from_slice(&[0x00, 0x01, 0x02, 0x03]);
+        out
+    }
+
+    /// An archive of `(path, bytes)` chunks, as the builder compresses it.
+    fn build_wad(chunks: &[(&str, Vec<u8>)]) -> Wad<Cursor<Vec<u8>>> {
+        let mut builder = WadBuilder::default();
+        for (path, _) in chunks {
+            builder = builder.with_chunk(WadChunkBuilder::default().with_path(*path));
+        }
+        let mut buffer = Cursor::new(Vec::new());
+        builder
+            .build_to_writer(&mut buffer, |path_hash, cursor| {
+                let (_, bytes) = chunks
+                    .iter()
+                    .find(|(path, _)| hash_wad_path(path) == path_hash)
+                    .expect("every hash is one of the chunks");
+                cursor.write_all(bytes)?;
+                Ok(())
+            })
+            .unwrap();
+        buffer.set_position(0);
+        Wad::mount(buffer).unwrap()
+    }
+
+    #[test]
+    fn hash_wad_path_is_xxh64_of_the_lower_case_path() {
+        assert_eq!(hash_wad_path("ASSETS/X.dds"), xxh64(b"assets/x.dds", 0));
+        assert_eq!(hash_wad_path("assets/x.dds"), xxh64(b"assets/x.dds", 0));
+    }
+
+    #[test]
+    fn candidates_are_the_length_prefixed_strings() {
+        let mut data = vec![0xde, 0xad];
+        bin_string(&mut data, "assets/foo.dds");
+        data.extend_from_slice(&[0xff, 0xfe]);
+        bin_string(&mut data, "a/b.bin");
+        /* 32 bytes long, so the low byte of its length is a printable space
+        that joins the run before it. The lengths still bound both. */
+        bin_string(&mut data, "data/characters/aatrox/x.anm_ext");
+        data.extend_from_slice(&[0x00, 0x00]);
+        bin_string(&mut data, "noise");
+
+        assert_eq!(
+            collect_candidates(&data),
+            vec![
+                "assets/foo.dds".to_string(),
+                "a/b.bin".to_string(),
+                "data/characters/aatrox/x.anm_ext".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn nothing_runs_when_every_chunk_is_named() {
+        let mut wad = build_wad(&[
+            ("data/test.bin", bin_with(&["assets/a.dds"])),
+            ("assets/a.dds", vec![0xab; 16]),
+        ]);
+        let mut resolver = HashMapPathResolver::default();
+        resolver.insert(hash_wad_path("data/test.bin"), "data/test.bin".into());
+        resolver.insert(hash_wad_path("assets/a.dds"), "assets/a.dds".into());
+
+        let recovered = NameRecovery::new().run(&mut wad, &resolver).unwrap();
+
+        assert_eq!(recovered, RecoveredNames::default());
+    }
+
+    #[test]
+    fn a_named_bin_names_the_chunks_it_links() {
+        let asset = "ASSETS/Characters/Foo/Recovered.dds";
+        let mut wad = build_wad(&[
+            ("data/test.bin", bin_with(&[asset])),
+            (asset, vec![0xab; 32]),
+        ]);
+        let mut resolver = HashMapPathResolver::default();
+        resolver.insert(hash_wad_path("data/test.bin"), "data/test.bin".into());
+
+        let recovered = NameRecovery::new().run(&mut wad, &resolver).unwrap();
+
+        assert_eq!(recovered.get(hash_wad_path(asset)), Some(asset));
+        assert_eq!(recovered.len(), 1);
+        assert_eq!(recovered.bins_scanned, 1);
+        /* The asset was sniffed, and the named bin was not. */
+        assert_eq!(recovered.chunks_sniffed, 1);
+        assert!(!recovered
+            .names
+            .contains_key(&hash_wad_path("data/test.bin")));
+    }
+
+    #[test]
+    fn an_anonymous_bin_is_found_by_its_first_bytes() {
+        let asset = "assets/orphan/asset.dds";
+        let mut wad = build_wad(&[
+            ("data/orphan.bin", bin_with(&[asset])),
+            (asset, vec![0xee; 16]),
+        ]);
+
+        let recovered = NameRecovery::new().run(&mut wad, &HexPathResolver).unwrap();
+
+        assert_eq!(recovered.get(hash_wad_path(asset)), Some(asset));
+        assert_eq!(recovered.chunks_sniffed, 2);
+        assert_eq!(recovered.bins_scanned, 1);
+    }
+
+    #[test]
+    fn a_set_cancel_flag_returns_what_was_found() {
+        let mut wad = build_wad(&[
+            ("data/test.bin", bin_with(&["assets/a.dds"])),
+            ("assets/a.dds", vec![0xab; 16]),
+        ]);
+        let flag = AtomicBool::new(true);
+
+        let recovered = NameRecovery::new()
+            .with_cancel_flag(&flag)
+            .run(&mut wad, &HexPathResolver)
+            .unwrap();
+
+        assert!(recovered.is_empty());
+        assert_eq!(recovered.bins_scanned, 0);
+    }
+
+    #[test]
+    fn the_layered_resolver_reads_recovered_names_first() {
+        let mut recovered = RecoveredNames::default();
+        recovered.names.insert(0x1234, "assets/found.dds".into());
+        let mut fallback = HashMapPathResolver::default();
+        fallback.insert(0x5678, "assets/known.dds".into());
+
+        let layered = recovered.over(&fallback);
+
+        assert_eq!(layered.resolve(0x1234), "assets/found.dds");
+        assert_eq!(layered.resolve(0x5678), "assets/known.dds");
+        assert_eq!(layered.resolve(0x9abc), "0000000000009abc");
+        assert!(layered.is_known(0x1234));
+        assert!(layered.is_known(0x5678));
+        assert!(!layered.is_known(0x9abc));
+    }
+
+    #[test]
+    fn the_extractor_writes_a_recovered_name() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let output_path = Utf8Path::from_path(temp_dir.path()).unwrap();
+
+        let asset = "assets/characters/foo/recovered.dds";
+        let mut wad = build_wad(&[
+            ("data/test.bin", bin_with(&[asset])),
+            (asset, vec![0xab; 32]),
+        ]);
+        let mut resolver = HashMapPathResolver::default();
+        resolver.insert(hash_wad_path("data/test.bin"), "data/test.bin".into());
+
+        let report = WadExtractor::new(&resolver)
+            .with_name_recovery()
+            .with_layout(ExtractLayout::Paths)
+            .extract_all(&mut wad, output_path)
+            .unwrap();
+
+        assert_eq!(report.extracted, 2);
+        assert_eq!(report.recovered_names.len(), 1);
+        assert!(temp_dir.path().join(asset).exists());
+        assert!(temp_dir.path().join("data/test.bin").exists());
+    }
+}

--- a/crates/ltk_wad/src/recovery.rs
+++ b/crates/ltk_wad/src/recovery.rs
@@ -1,24 +1,9 @@
 //! Recovering chunk names from the `.bin` files of an archive.
 //!
-//! A WAD keys a chunk by the hash of its path and stores no path. A hash table
-//! names most chunks, and the rest extract as sixteen hex digits. League's
-//! `.bin` files name the assets they use by path, as linked files and as string
-//! properties, so the paths of many anonymous chunks sit inside the archive
-//! itself. This module reads them out.
-//!
-//! A match is exact: a string counts only when its hash is the hash of a chunk
-//! the resolver could not name, so a string that is not a path never matches.
-//!
-//! # How it stays cheap
-//!
-//! - Nothing runs when the resolver names every chunk.
-//! - A bin is found by its name, or by its first bytes. The first bytes come
-//!   from the first compressed block alone, so an anonymous texture costs one
-//!   block and not the whole chunk.
-//! - Strings are read out of the bytes as the length-prefixed runs the format
-//!   writes them as, with no parse of the object tree in between.
-//! - The bins decompress on worker threads, and the scan stops as soon as every
-//!   anonymous chunk has a name.
+//! - The scan tells a bin from any other chunk by its magic, decoded from the
+//!   first compressed block alone.
+//! - The scan reads the strings of a bin as the length-prefixed runs the format
+//!   writes, with no parse of the `PROP` data.
 //!
 //! # Example
 //!
@@ -93,7 +78,7 @@ pub struct RecoveredNames {
     pub names: HashMap<WadHash, String>,
     /// Bins read for the names.
     pub bins_scanned: usize,
-    /// Chunks whose first bytes were read because nothing named them.
+    /// Chunks whose first bytes the scan read because nothing named them.
     pub chunks_sniffed: usize,
 }
 
@@ -184,7 +169,7 @@ impl<'a> NameRecovery<'a> {
 
     /// Stop early once `flag` reads `true`.
     ///
-    /// The names found so far are returned, and a stop is not an error.
+    /// [`run`](Self::run) returns the names found so far, and a stop is not an error.
     pub fn with_cancel_flag(mut self, flag: &'a AtomicBool) -> Self {
         self.cancel = Some(flag);
         self
@@ -194,9 +179,9 @@ impl<'a> NameRecovery<'a> {
     ///
     /// # Errors
     ///
-    /// Fails when the archive cannot be read, with a [`WadError::Chunk`] that
-    /// names the bin. A bin that does not decompress is skipped, because one
-    /// bad bin is no reason to lose the names in the rest.
+    /// Fails when the recovery cannot read the archive, with a [`WadError::Chunk`]
+    /// that names the bin. The recovery skips a bin that does not decompress,
+    /// because one bad bin is no reason to lose the names in the rest.
     pub fn run<S: Read + Seek, R: PathResolver + ?Sized>(
         &self,
         wad: &mut Wad<S>,
@@ -246,7 +231,7 @@ impl<'a> NameRecovery<'a> {
         let (sender, receiver) = mpsc::sync_channel::<RawChunk>(workers);
         let receiver = Mutex::new(receiver);
 
-        /* Taken inside the scope so it drops before the workers are joined.
+        /* Taken inside the scope so it drops before the scope joins the workers.
         A worker only stops once every sender is gone. */
         let mut sender = Some(sender);
         let scanned = thread::scope(|scope| {
@@ -326,7 +311,7 @@ fn sniff_is_bin<S: Read + Seek>(
         };
         match decoder.decompress_prefix(&raw, chunk.compression_type, SNIFF_BYTES) {
             Ok(head) if head.len() >= wanted => return is_bin_magic(&head),
-            /* The first block was cut short, and the chunk holds more. */
+            /* The prefix cut the first block short, and the chunk holds more. */
             _ if raw.len() == limit && limit < SNIFF_RAW_BYTES => limit = SNIFF_RAW_BYTES,
             _ => return false,
         }
@@ -354,7 +339,7 @@ fn is_printable(byte: u8) -> bool {
 ///
 /// The format writes a string as a little-endian `u16` length and the bytes,
 /// with no terminator. A path is printable ASCII and its length's high byte is
-/// zero, so each run of printable bytes starts on a string's first byte, and
+/// zero. So each run of printable bytes starts on a string's first byte, and
 /// the two bytes in front of the run are its length. The length then bounds
 /// the string exactly, however many printable bytes follow it, such as the low
 /// byte of the next string's length.
@@ -498,7 +483,7 @@ mod tests {
         assert_eq!(recovered.get(WadHash::hash_str(asset)), Some(asset));
         assert_eq!(recovered.len(), 1);
         assert_eq!(recovered.bins_scanned, 1);
-        /* The asset was sniffed, and the named bin was not. */
+        /* The recovery sniffed the asset, and not the named bin. */
         assert_eq!(recovered.chunks_sniffed, 1);
         assert!(!recovered
             .names

--- a/docs/LTK_GUIDE.md
+++ b/docs/LTK_GUIDE.md
@@ -39,8 +39,9 @@ ltk_texture = "0.4"
 - `WadBuilder` - Creates new WAD archives
 - `WadExtractor` - Extracts chunks to disk with progress callbacks
 - `PathResolver` trait - Maps path hashes to human-readable paths
+- `WadHash` - A chunk's key, re-exported from `ltk_hash`
 
-**WAD Path Hashing**: Files in WAD archives are identified by 64-bit path hashes (XXHash64 of lowercase path). Use a "hashtable" (hash→path mapping) to resolve paths.
+**WAD Path Hashing**: Files in WAD archives are identified by 64-bit path hashes (XXHash64 of lowercase path), typed as `ltk_hash::WadHash`. `WadHash::hash_str(path)` hashes a path (bring `ltk_hash::Hash` into scope), and a `WadChunkLink` read out of a bin holds the same type. Use a "hashtable" (hash→path mapping) to resolve paths.
 
 **Example: Reading a WAD**
 ```rust
@@ -65,11 +66,11 @@ if let Some(chunk) = chunks.get(&0x1234567890abcdef) {
 **Example: Extracting with Progress**
 ```rust
 use std::collections::HashMap;
-use ltk_wad::{Wad, WadExtractor};
+use ltk_wad::{Wad, WadExtractor, WadHash};
 
 let mut wad = Wad::mount(File::open("archive.wad.client")?)?;
-// A `HashMap<u64, String>` is a resolver. `NoResolver` names nothing.
-let names: HashMap<u64, String> = load_hashtable()?;
+// A `HashMap<WadHash, String>` is a resolver. `NoResolver` names nothing.
+let names: HashMap<WadHash, String> = load_hashtable()?;
 
 let mut extractor = WadExtractor::new(&names)
     .with_filter(|path| path.starts_with("assets/"))

--- a/docs/LTK_GUIDE.md
+++ b/docs/LTK_GUIDE.md
@@ -41,7 +41,7 @@ ltk_texture = "0.4"
 - `PathResolver` trait - Maps path hashes to human-readable paths
 - `WadHash` - A chunk's key, re-exported from `ltk_hash`
 
-**WAD Path Hashing**: Files in WAD archives are identified by 64-bit path hashes (XXHash64 of lowercase path), typed as `ltk_hash::WadHash`. `WadHash::hash_str(path)` hashes a path (bring `ltk_hash::Hash` into scope), and a `WadChunkLink` read out of a bin holds the same type. Use a "hashtable" (hash→path mapping) to resolve paths.
+**WAD Path Hashing**: A 64-bit path hash (XXHash64 of the lowercase path), typed as `ltk_hash::WadHash`, identifies each file in a WAD archive. `WadHash::hash_str(path)` hashes a path (bring `ltk_hash::Hash` into scope), and a `WadChunkLink` read out of a bin holds the same type. Use a "hashtable" (hash→path mapping) to resolve paths.
 
 **Example: Reading a WAD**
 ```rust
@@ -84,7 +84,7 @@ println!("{report}");
 the archive lacks under `report.missing`. `with_layout(ExtractLayout::Flat)`
 drops the directories, and `with_existing_file_policy(ExistingFilePolicy::Skip)`
 leaves files that exist. `with_name_recovery()` reads the archive's `.bin` files
-for the names of chunks the hash table lacks, before anything is written.
+for the names of chunks the hash table lacks, before it writes anything.
 `NameRecovery` runs the same scan on its own. A failure names its chunk through
 `WadError::Chunk`.
 

--- a/docs/LTK_GUIDE.md
+++ b/docs/LTK_GUIDE.md
@@ -79,6 +79,9 @@ println!("{} chunks, {} bytes", report.extracted, report.bytes_written);
 `extract_chunks` takes a slice of the archive's chunks instead of all of them.
 `with_layout(ExtractLayout::Flat)` drops the directories, and
 `with_existing_file_policy(ExistingFilePolicy::Skip)` leaves files that exist.
+`with_name_recovery()` reads the archive's `.bin` files for the names of chunks the
+hash table lacks, before anything is written. `NameRecovery` runs the same scan on
+its own.
 
 **Compression Types**:
 - `None` - Uncompressed

--- a/docs/LTK_GUIDE.md
+++ b/docs/LTK_GUIDE.md
@@ -72,9 +72,13 @@ let resolver = HashMapPathResolver::new(load_hashtable()?);
 let extractor = WadExtractor::new(&resolver)
     .on_progress(|p| println!("{:.0}% - {}", p.percent() * 100.0, p.current_path()));
 
-let (mut decoder, chunks) = wad.decode();
-extractor.extract_all(&mut decoder, chunks, "./output")?;
+let report = extractor.extract_all(&mut wad, "./output")?;
+println!("{} chunks, {} bytes", report.extracted, report.bytes_written);
 ```
+
+`extract_chunks` takes a slice of the archive's chunks instead of all of them.
+`with_layout(ExtractLayout::Flat)` drops the directories, and
+`with_existing_file_policy(ExistingFilePolicy::Skip)` leaves files that exist.
 
 **Compression Types**:
 - `None` - Uncompressed

--- a/docs/LTK_GUIDE.md
+++ b/docs/LTK_GUIDE.md
@@ -64,24 +64,28 @@ if let Some(chunk) = chunks.get(&0x1234567890abcdef) {
 
 **Example: Extracting with Progress**
 ```rust
-use ltk_wad::{Wad, WadExtractor, HashMapPathResolver};
+use std::collections::HashMap;
+use ltk_wad::{Wad, WadExtractor};
 
 let mut wad = Wad::mount(File::open("archive.wad.client")?)?;
-let resolver = HashMapPathResolver::new(load_hashtable()?);
+// A `HashMap<u64, String>` is a resolver. `NoResolver` names nothing.
+let names: HashMap<u64, String> = load_hashtable()?;
 
-let extractor = WadExtractor::new(&resolver)
-    .on_progress(|p| println!("{:.0}% - {}", p.percent() * 100.0, p.current_path()));
+let mut extractor = WadExtractor::new(&names)
+    .with_filter(|path| path.starts_with("assets/"))
+    .on_progress(|p| println!("{:.0}% - {}", p.fraction() * 100.0, p.path()));
 
 let report = extractor.extract_all(&mut wad, "./output")?;
-println!("{} chunks, {} bytes", report.extracted, report.bytes_written);
+println!("{report}");
 ```
 
-`extract_chunks` takes a slice of the archive's chunks instead of all of them.
-`with_layout(ExtractLayout::Flat)` drops the directories, and
-`with_existing_file_policy(ExistingFilePolicy::Skip)` leaves files that exist.
-`with_name_recovery()` reads the archive's `.bin` files for the names of chunks the
-hash table lacks, before anything is written. `NameRecovery` runs the same scan on
-its own.
+`extract_chunks` takes path hashes instead of every chunk, and lists the hashes
+the archive lacks under `report.missing`. `with_layout(ExtractLayout::Flat)`
+drops the directories, and `with_existing_file_policy(ExistingFilePolicy::Skip)`
+leaves files that exist. `with_name_recovery()` reads the archive's `.bin` files
+for the names of chunks the hash table lacks, before anything is written.
+`NameRecovery` runs the same scan on its own. A failure names its chunk through
+`WadError::Chunk`.
 
 **Compression Types**:
 - `None` - Uncompressed
@@ -652,7 +656,7 @@ use glam::{Vec2, Vec3, Vec4, Mat4, Quat};
 
 ```rust
 use std::fs::File;
-use ltk_wad::{Wad, WadExtractor, HashMapPathResolver};
+use ltk_wad::{Wad, WadExtractor};
 use ltk_file::LeagueFileKind;
 use ltk_texture::Texture;
 use ltk_mesh::SkinnedMesh;


### PR DESCRIPTION
Implements the wad extractor API from `wadtools` and improves upon it with worker parallelism and a dedicated chunk decoder API