### PR TITLE
feat(meta): re-export the streaming surface from the crate root

### DIFF
--- a/.scratch/bin-streaming/issues/05-ptch-stream.md
+++ b/.scratch/bin-streaming/issues/05-ptch-stream.md
@@ -77,6 +77,8 @@ impl<R: io::Read + io::Seek, M: Default> BinFileStream<R, M> {
 
 `PatchStream::path()` returns `&PropertyPath`, not `&str` — `PropertyPatch::path` is already a `PropertyPath`, so anything less would force callers to re-parse. `BinOverride::from_reader` joins the single decode path (mount + `into_bin_override`).
 
+Parked: no consumer, and no gap behind it. The eager `BinOverride` — with the `data_override/{read,write}.rs` split under it — already closed the real downstream need, which was an unimplemented override *write* path; nothing downstream wants a patch bin read lazily. The design stands as written, so this stays open rather than closed: pick it up when a consumer wants a PTCH file's records without its tree, which is the want that drove #192 for PROP. Until then `BinOverrideStream` and `BinFileStream` do not exist, and the `concrete` aliases [section 4](https://github.com/LeagueToolkit/league-toolkit/blob/main/docs/design/bin-streaming.md#s4) says they want are part of this ticket rather than of the shipped surface.
+
 Demoable: every shipped PTCH file in an install streams — headers, objects, all records — and drains to an eager value equal to the direct eager parse.
 
 - [ ] All shipped PTCH chunks in an install (238 at last count) mount, stream every record, and `into_bin_override()` equals the eager parse

--- a/.scratch/bin-streaming/issues/06-delta-write-back.md
+++ b/.scratch/bin-streaming/issues/06-delta-write-back.md
@@ -44,6 +44,14 @@ impl<R: io::Read + io::Seek, M: Default + Clone> BinStream<R, M> {
 
 This completes the bin editor's loop end to end: mount → TOC rows → `view()` to browse → `read()` on first edit → mutate through the value-slot surface → `write_patched` to a temp file → rename → remount. (The editing path takes `read()`, never `cached_object()` — the cache hands out shared `Arc`s, and an edit wants exclusive ownership; `Arc::make_mut` is the escape hatch when both are wanted.)
 
+Parked, on three arguments rather than on time:
+
+- **There is no fidelity to recover.** The downstream consumer's own accepted decision record has a bin repair re-encode the whole file, and states that the bytes it did not address come back the same. Byte-exact copy-through of untouched objects buys a guarantee that consumer already holds.
+- **This design already treats a uniform re-encode as correct output.** The legacy refusal above names a full `into_bin()` + `to_writer` transcode as the fallback for a latched base ([section 8](https://github.com/LeagueToolkit/league-toolkit/blob/main/docs/design/bin-streaming.md#s8)) — a whole-file re-encode is a supported way to save, not a lossy last resort.
+- **A delta write *introduces* a refusal case a re-encode does not have.** That refusal exists only because raw-copied and re-encoded objects can disagree about kind numbering. A consumer that always re-encodes never meets a mixed-numbering file, and carries no fallback path for one.
+
+What is left is a CPU saving, and it is unmeasured. So this comes back with a number attached: `into_bin()` + `to_writer` measured as a share of a repair's wall-clock, once the streaming reads are adopted downstream. If the transcode is a visible share of that time, the delta writer earns its refusal case; if it is noise, it does not.
+
 - [ ] An empty delta reproduces the input byte-for-byte, for every PROP chunk in an install (corpus test)
 - [ ] A one-property edit re-reads equal to the same edit applied to the eager tree, and every other object's bytes are unchanged
 - [ ] A version-1/2 base saves with its header version intact; editing an object re-encodes that object without upgrading the header

--- a/.scratch/bin-streaming/issues/08-streaming-resolve.md
+++ b/.scratch/bin-streaming/issues/08-streaming-resolve.md
@@ -68,7 +68,13 @@ pub enum Error {
 
 Unblocked: #208 and #209 shipped the views and the layout core this runs on.
 
-Deliberately unscheduled. [section 11](https://github.com/LeagueToolkit/league-toolkit/blob/main/docs/design/bin-streaming.md#s11) defers this until a consumer exists — it is thin enough that building it early risks fitting it to a guess. The named consumer in #192 is the bin grepping API; the bin editor's link-chasing is a second. Pick it up when one of those lands, or when a third asks.
+Still unscheduled, and now against a consumer rather than by default. [section 11](https://github.com/LeagueToolkit/league-toolkit/blob/main/docs/design/bin-streaming.md#s11) defers this until a consumer exists, and the one it was expected to serve was checked against its own code:
+
+- **It already reaches its target in O(1).** The downstream repair path keys objects by path hash and skips every object it holds no finding for, so it never scans for the object. The walk `resolve` would do inside the object it has reached is the work itself, not work saved.
+- **It persists no paths.** Its mismatch record is `{ expected, found }`, so there is no stored path grammar a streaming walk would have to stay compatible with, and nothing gets cheaper by front-loading one.
+- **The saving needs a caller that does not want the whole tree** — which is the read half of the delta flow, so this couples to #211, parked for reasons of its own.
+
+So it stays a follow-on: open, unscheduled, and thin enough that building it early would fit it to a guess. #192 names the bin grepping API, and the bin editor's link-chasing is a second candidate. Pick it up when one of them walks a path into an object it does not otherwise want, which is what turns the skipped siblings into a saving.
 
 - [ ] `ObjectView::resolve` and `StructView::resolve` walk only the properties on the path; siblings are skipped, nothing is materialized (attested by counting decoded leaves)
 - [ ] Differential test: for a sampled set of paths per corpus object, streaming resolve and `BinObject::resolve` agree on the value, and on `ResolveError`'s segment and kind when they fail

--- a/crates/ltk_anim/src/rig/write.rs
+++ b/crates/ltk_anim/src/rig/write.rs
@@ -2,6 +2,7 @@ use super::RigResource;
 use byteorder::{WriteBytesExt, LE};
 use ltk_hash::elf;
 use ltk_io_ext::WriterExt;
+use std::cmp::Reverse;
 use std::io;
 use std::io::{Seek, SeekFrom, Write};
 
@@ -68,7 +69,7 @@ impl RigResource {
             .iter()
             .map(|j| (j.id(), elf::elf(j.name())))
             .collect::<Vec<_>>();
-        hash_ids.sort_by(|a, b| b.1.cmp(&a.1));
+        hash_ids.sort_by_key(|(_, hash)| Reverse(*hash));
 
         for (id, hash) in hash_ids {
             writer.write_i16::<LE>(id)?;

--- a/crates/ltk_meta/README.md
+++ b/crates/ltk_meta/README.md
@@ -13,12 +13,12 @@ Two kinds of file share the `.bin` extension and this crate reads both:
 | --- | --- |
 | `Bin`, `BinObject` | The object tree: read (`from_reader`), build (`builder()`), edit, write (`to_writer`) |
 | `BinStream`, `BinToc`, `ObjectEntry`, `BatchObjects` | Streaming access: mount a file, sweep object descriptors, random access by path hash, and whole batches of them at once - without parsing values |
-| `stream::ObjectView`, `PropertyView`, `ValueView` | Zero-copy views over one buffered object: iterate, look up and descend to any depth without materializing anything |
-| `stream::ObjectCache`, `NoCache`, `LruObjectCache` | The opt-in lookup cache `BinStream::cached_object` resolves through |
-| `stream::Numbering` | Which property-kind numbering a file is being read under, and whether the legacy latch has flipped |
+| `ObjectView`, `PropertyView`, `ValueView` | Zero-copy views over one buffered object: iterate, look up and descend to any depth without materializing anything |
+| `ObjectCache`, `NoCache`, `LruObjectCache` | The opt-in lookup cache `BinStream::cached_object` resolves through |
+| `Numbering` | Which property-kind numbering a file is being read under, and whether the legacy latch has flipped |
 | `property::values`, `PropertyValueEnum`, `PropertyKind` | One typed value struct per wire kind (`I32`, `String`, `Vector3`, `Container`, `Map`, `Struct`, `Embedded`, `Optional`, …) and the enum over them |
 | `ValueSlot` | A mutable handle on one value, carrying the kind its holder pins it to - what `resolve_mut` hands back |
-| `concrete` | The same types with the metadata parameter pinned, so nothing generic needs spelling - start here |
+| `concrete` | The value model with the metadata parameter pinned - start here - plus the three streaming names Rust cannot infer without it: `BinStream`, `LruObjectCache`, `NoCache` |
 | `path::PropertyPath` | Property addressing (`Position.Anchors.Anchor`, `Elements[3]`, `Lookup{"weapon"}`), with `Bin::resolve`, `resolve_mut` and `Bin::patch` |
 | `path::ValueShape` | What a value is - kind, item kind, map key kind, embed class - as the resolver's type rule and the streaming header peek both speak it |
 | `BinOverride`, `ApplyReport` | PTCH files: read, build, `check` against / `apply` onto a base `Bin` |
@@ -83,7 +83,7 @@ Descending buffers the object's declared byte range once and views it in place. 
 
 ```rust
 use std::fs::File;
-use ltk_meta::{concrete::BinStream, stream::ValueView};
+use ltk_meta::{concrete::BinStream, ValueView};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut stream = BinStream::mount(File::open("data.bin")?)?;
@@ -152,7 +152,7 @@ Bins written before `WadChunkLink` existed number the complex kinds one lower. A
 
 ```rust
 use std::fs::File;
-use ltk_meta::{concrete::BinStream, stream::Numbering};
+use ltk_meta::{concrete::BinStream, Numbering};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut stream = BinStream::mount(File::open("data.bin")?)?;

--- a/crates/ltk_meta/src/concrete.rs
+++ b/crates/ltk_meta/src/concrete.rs
@@ -23,14 +23,35 @@
 //! # assert_eq!(bin.objects.len(), 1);
 //! ```
 //!
+//! The streaming surface splits along the same line. Its views and cursors are only ever named
+//! in type position, where the default already applies, so they come from the crate root. What
+//! needs an alias is what a caller writes in *expression* position: [`BinStream::mount`] and
+//! [`LruObjectCache::new`]. [`NoCache`] is not generic and so pins nothing; it is re-exported
+//! rather than aliased, because an associated function like `new` resolves through a type alias
+//! but a unit struct's value constructor does not - so that a cache policy and its LRU sibling
+//! are still named from one import.
+//!
+//! ```no_run
+//! use std::{fs::File, num::NonZeroUsize};
+//! use ltk_meta::concrete::{BinStream, LruObjectCache};
+//!
+//! let mut stream = BinStream::mount(File::open("data.bin")?)?;
+//! stream.set_cache(Box::new(LruObjectCache::new(NonZeroUsize::try_from(64)?)));
+//! # Ok::<(), Box<dyn std::error::Error>>(())
+//! ```
+//!
 //! Code that carries metadata (such as `ltk_ritobin`, which threads source spans)
 //! keeps using the generic types directly.
 //!
 //! [`NoMeta`]: crate::property::NoMeta
+//! [`BinStream::mount`]: crate::stream::BinStream::mount
+//! [`LruObjectCache::new`]: crate::stream::LruObjectCache::new
 
 pub type Bin = crate::Bin;
 pub type BinObject = crate::BinObject;
 pub type BinStream<R> = crate::stream::BinStream<R>;
+pub type LruObjectCache = crate::stream::LruObjectCache;
+pub use crate::stream::NoCache;
 pub type BinFile = crate::BinFile;
 pub type BinOverride = crate::BinOverride;
 pub type PropertyPatch = crate::PropertyPatch;

--- a/crates/ltk_meta/src/lib.rs
+++ b/crates/ltk_meta/src/lib.rs
@@ -76,7 +76,7 @@ iteration and descent to any depth cost no I/O and materialize nothing:
 
 ```no_run
 use std::fs::File;
-use ltk_meta::{concrete::BinStream, stream::ValueView};
+use ltk_meta::{concrete::BinStream, ValueView};
 
 let mut stream = BinStream::mount(File::open("data.bin")?)?;
 let mut objects = stream.objects();
@@ -225,8 +225,9 @@ pub use file::{BinFile, BinKind};
 
 pub mod stream;
 pub use stream::{
-    BatchObjects, BinStream, BinToc, Entries, Numbering, ObjectEntry, ObjectStream, ObjectView,
-    Objects, PropertyView, ValueView,
+    BatchObjects, BinStream, BinToc, ContainerItems, ContainerView, Entries, LruObjectCache,
+    MapEntries, MapView, NoCache, Numbering, ObjectCache, ObjectEntry, ObjectStream, ObjectView,
+    Objects, OptionalView, Properties, PropertyView, StructView, ValueView,
 };
 
 mod error;

--- a/crates/ltk_meta/src/stream/cache.rs
+++ b/crates/ltk_meta/src/stream/cache.rs
@@ -19,7 +19,7 @@ use crate::{property::NoMeta, BinObject};
 ///
 /// [`Arc<BinObject<M>>`](Arc) is the currency: a hit is an `Arc` clone, so callers keep values
 /// as long as they like, eviction never invalidates anything, and the values cross threads.
-pub trait ObjectCache<M> {
+pub trait ObjectCache<M = NoMeta> {
     /// The cached object for `key`, if the provider holds one.
     fn get(&mut self, key: BinHash) -> Option<Arc<BinObject<M>>>;
 

--- a/crates/ltk_meta/tests/import_surface.rs
+++ b/crates/ltk_meta/tests/import_surface.rs
@@ -1,0 +1,248 @@
+//! The streaming surface, imported the way a consumer is meant to import it.
+//!
+//! Two paths appear in this file and no more: `ltk_meta::concrete` for the constructors Rust
+//! cannot infer - `mount` and `LruObjectCache::new` are expression position, where the
+//! `M = NoMeta` default never applies - and the crate root for everything else. The path
+//! `ltk_meta::stream` must not appear here at all: needing it is the two-import-site spread the
+//! root re-exports removed, and this file is what catches it coming back.
+//!
+//! The handle is mounted with no turbofish and no annotation, which is the other half of the
+//! assertion: `R` and `M` are inferred once and carry through every cursor and view it hands out.
+
+use std::{io::Cursor, num::NonZeroUsize, sync::Arc};
+
+use ltk_meta::{
+    concrete::{BinStream, LruObjectCache, NoCache},
+    BatchObjects, BinToc, ContainerItems, ContainerView, Entries, Error, MapEntries, MapView,
+    Numbering, ObjectCache, ObjectEntry, ObjectStream, ObjectView, Objects, OptionalView,
+    Properties, PropertyView, StructView, ValueView,
+};
+
+/// Path hash of the fixture's only object.
+const PATH_HASH: u32 = 0x8066_f665;
+/// Its class, `VfxSystemDefinitionData`.
+const CLASS_HASH: u32 = 0x45cd_899f;
+/// Its first property: a container holding one emitter definition.
+const EMITTERS: u32 = 0x868e_b76a;
+/// The class of that emitter.
+const EMITTER_CLASS: u32 = 0x09cd_e442;
+
+/// A consumer that keeps its cache policy rather than handing it straight over.
+///
+/// The field is the strict case: `set_cache` lets an argument infer `M`, but a field has no
+/// inference to lean on, so `ObjectCache`'s own `M = NoMeta` default is what keeps this to one
+/// import instead of three.
+struct CacheHolder {
+    policy: Box<dyn ObjectCache + Send>,
+}
+
+/// What a full descent met, so the walk asserts something beyond having compiled.
+#[derive(Debug, Default, PartialEq, Eq)]
+struct Tally {
+    structs: usize,
+    containers: usize,
+    maps: usize,
+    optionals: usize,
+    strings: usize,
+}
+
+/// Descends one value to the bottom, counting what it meets.
+///
+/// The four sub-views a `ValueView` opens into are named in the helpers' parameter lists rather
+/// than behind a turbofish, which is what proves the root re-exports carry `M = NoMeta` with them.
+fn walk_value(value: ValueView<'_>, tally: &mut Tally) -> Result<(), Error> {
+    match value {
+        ValueView::String(_) => tally.strings += 1,
+        ValueView::Container(list) | ValueView::UnorderedContainer(list) => {
+            walk_container(list, tally)?;
+        }
+        ValueView::Map(map) => walk_map(map, tally)?,
+        ValueView::Optional(option) => walk_optional(option, tally)?,
+        ValueView::Struct(nested) | ValueView::Embedded(nested) => walk_struct(nested, tally)?,
+        // Listed rather than caught by `_`: a new composite view must fail here until it is
+        // named at the root too.
+        ValueView::None
+        | ValueView::Bool(_)
+        | ValueView::I8(_)
+        | ValueView::U8(_)
+        | ValueView::I16(_)
+        | ValueView::U16(_)
+        | ValueView::I32(_)
+        | ValueView::U32(_)
+        | ValueView::I64(_)
+        | ValueView::U64(_)
+        | ValueView::F32(_)
+        | ValueView::Vector2(_)
+        | ValueView::Vector3(_)
+        | ValueView::Vector4(_)
+        | ValueView::Matrix44(_)
+        | ValueView::Color(_)
+        | ValueView::Hash(_)
+        | ValueView::WadChunkLink(_)
+        | ValueView::ObjectLink(_)
+        | ValueView::BitBool(_) => {}
+    }
+    Ok(())
+}
+
+fn walk_struct(view: StructView<'_>, tally: &mut Tally) -> Result<(), Error> {
+    tally.structs += 1;
+    for property in view.properties() {
+        walk_value(property?.value_view()?, tally)?;
+    }
+    Ok(())
+}
+
+fn walk_container(view: ContainerView<'_>, tally: &mut Tally) -> Result<(), Error> {
+    tally.containers += 1;
+    let items: ContainerItems<'_> = view.iter();
+    for item in items {
+        walk_value(item?, tally)?;
+    }
+    Ok(())
+}
+
+fn walk_map(view: MapView<'_>, tally: &mut Tally) -> Result<(), Error> {
+    tally.maps += 1;
+    let entries: MapEntries<'_> = view.iter();
+    for entry in entries {
+        let (key, value) = entry?;
+        walk_value(key, tally)?;
+        walk_value(value, tally)?;
+    }
+    Ok(())
+}
+
+fn walk_optional(view: OptionalView<'_>, tally: &mut Tally) -> Result<(), Error> {
+    tally.optionals += 1;
+    if let Some(value) = view.get()? {
+        walk_value(value, tally)?;
+    }
+    Ok(())
+}
+
+#[test]
+fn a_streaming_walk_needs_only_the_root_and_concrete() -> Result<(), Error> {
+    let mut stream = BinStream::mount(Cursor::new(include_bytes!("bins/leona_small.bin")))?;
+
+    assert_eq!(stream.version(), 3);
+    assert_eq!(stream.class_hashes().len(), 1);
+
+    let mut tally = Tally::default();
+    let mut swept = 0;
+    let mut objects = stream.objects();
+
+    while let Some(mut object) = objects.next()? {
+        swept += 1;
+        assert_eq!(object.path_hash(), PATH_HASH.into());
+        assert_eq!(object.class_hash(), CLASS_HASH.into());
+
+        let view = object.view()?;
+        assert_eq!(view.property_count(), 5);
+
+        for property in view.properties() {
+            walk_value(property?.value_view()?, &mut tally)?;
+        }
+    }
+
+    assert_eq!(swept, 1, "the fixture holds one object");
+    assert_eq!(
+        tally,
+        Tally {
+            // The container's one emitter, plus the struct embedded in it.
+            structs: 2,
+            containers: 1,
+            maps: 0,
+            optionals: 2,
+            // Three on the object, three inside the emitter.
+            strings: 6,
+        }
+    );
+
+    Ok(())
+}
+
+#[test]
+fn the_cache_policies_are_named_from_concrete() -> Result<(), Error> {
+    let mut stream = BinStream::mount(Cursor::new(include_bytes!("bins/leona_small.bin")))?;
+
+    // `new` is expression position, so the capacity comes through the `concrete` alias - and the
+    // annotation says the alias and the root re-export are one type.
+    let lru: ltk_meta::LruObjectCache =
+        LruObjectCache::new(NonZeroUsize::new(4).expect("4 is not zero"));
+    stream.set_cache(Box::new(lru));
+
+    let parsed = stream
+        .cached_object(PATH_HASH)?
+        .expect("the fixture's only object");
+    assert_eq!(parsed.properties.len(), 5);
+
+    let hit = stream
+        .cached_object(PATH_HASH)?
+        .expect("the same object, from the cache");
+    assert!(Arc::ptr_eq(&parsed, &hit), "the LRU served the second call");
+
+    // `NoCache` keeps nothing, so the next call parses a fresh object rather than hitting.
+    // Named in expression position straight from `concrete`, which is why it is re-exported
+    // there rather than aliased.
+    let holder = CacheHolder {
+        policy: Box::new(NoCache),
+    };
+    stream.set_cache(holder.policy);
+
+    let again = stream
+        .cached_object(PATH_HASH)?
+        .expect("the object, parsed again");
+    assert!(!Arc::ptr_eq(&parsed, &again), "NoCache has nothing to hit");
+
+    Ok(())
+}
+
+/// Every remaining streaming name, spelled at the crate root in type position.
+///
+/// The bindings are annotated on purpose here: a name the root stops exporting, or one whose
+/// metadata default stops applying through the re-export, fails to compile.
+#[test]
+fn every_streaming_name_is_spelled_at_the_crate_root() -> Result<(), Error> {
+    let mut stream = BinStream::mount(Cursor::new(include_bytes!("bins/leona_small.bin")))?;
+
+    let numbering: Numbering = stream.numbering();
+    assert_eq!(numbering, Numbering::Current);
+
+    let entries: Entries<'_, _> = stream.entries();
+    let descriptors = entries.collect::<Result<Vec<ObjectEntry>, Error>>()?;
+    assert_eq!(descriptors.len(), 1);
+    assert_eq!(descriptors[0].path_hash, PATH_HASH.into());
+
+    let toc: &BinToc = stream.toc()?;
+    assert_eq!(toc.entries().len(), 1);
+
+    let mut objects: Objects<'_, _> = stream.objects();
+    let mut object: ObjectStream<'_, _> = objects.next()?.expect("the fixture's only object");
+
+    let view: ObjectView<'_> = object.view()?;
+    let mut properties: Properties<'_> = view.properties();
+    let emitters: PropertyView<'_> = properties.next().expect("a first property")?;
+    assert_eq!(emitters.name_hash(), EMITTERS.into());
+
+    let ValueView::Container(list) = emitters.value_view()? else {
+        panic!("{EMITTERS:#010x} is the container of emitter definitions");
+    };
+    assert_eq!(list.len(), 1);
+
+    let Some(ValueView::Struct(emitter)) = list.get(0)? else {
+        panic!("the container holds one emitter struct");
+    };
+    assert_eq!(emitter.class_hash(), EMITTER_CLASS.into());
+
+    let mut batch: BatchObjects<'_, _> = stream.objects_batch([PATH_HASH, 0xdead_beef_u32]);
+    let mut found = 0;
+    while let Some(object) = batch.next()? {
+        found += 1;
+        assert_eq!(object.path_hash(), PATH_HASH.into());
+    }
+    assert_eq!(found, 1);
+    assert_eq!(batch.missing().len(), 1, "0xdeadbeef is not in this bin");
+
+    Ok(())
+}

--- a/docs/design/bin-streaming.md
+++ b/docs/design/bin-streaming.md
@@ -910,3 +910,50 @@ same objects the per-hash lookups do.
 The last row is the interesting one: nothing in a shipped install is written in the legacy
 numbering, which is what [section 8](#s8) expects. The latch is a guard, not a path - it exists for
 files older than anything Riot currently ships, and it is untested against real data by definition.
+
+## <a id="appendix-b"></a>Appendix B. Cache measurements, 2026-09-01
+
+What [section 4.4](#s4.4) is worth, measured rather than assumed. Run against a live install
+(40 of its 392 archives, 2,740 `PROP` chunks), with the sampled chunks written to disk and
+mounted as files, so a miss pays the seek and the read a real consumer pays. Best of five runs.
+
+**What a hit saves.** The 150 heaviest link sequences, 41.7 MB:
+
+| | per object |
+| --- | --- |
+| miss - seek, read, parse | 30,010 ns |
+| hit - an `Arc` clone | 105 ns |
+| saved per hit | 29,905 ns (286x) |
+
+**Pattern 1, harvested: an editor chasing `ObjectLink`s.** Every in-file link target in
+traversal order, which is the only cache-relevant access pattern a shipped file can attest to:
+
+| measurement | result |
+| --- | --- |
+| files carrying in-file links | 1,833 of 2,740 |
+| link references followed | 20,412 |
+| distinct targets | 17,321 |
+| ceiling hit rate, unbounded cache | 15.1% |
+| files where any target is referenced twice | 385 (21%) |
+| most references to one target | 499 |
+| `NoCache` to `LruObjectCache(32)` | 1.14x |
+| `NoCache` to `LruObjectCache(128)` | 1.20x |
+
+**Pattern 2, modelled: a working set re-requested.** The manager's "same objects across
+requests" has no signature in a file, so it is modelled rather than harvested - 16 objects per
+file, requested 8 times each. Labelled as a model on purpose:
+
+| policy | vs `NoCache` |
+| --- | --- |
+| `LruObjectCache(16)` | 8.29x |
+
+**What ties them.** From the two costs above, speedup is approximately `1 / (1 - hit_rate)`.
+That predicts 1.18x at pattern 1's 15.1% and 7.81x at pattern 2's 87.5%, against 1.14x-1.20x
+and 8.29x measured - so a consumer can predict its own payoff from its own hit rate without
+re-running any of this.
+
+Two things the numbers do not say. The miss cost is warm: the file is in the page cache by the
+second run, so 286x is a floor rather than a ceiling. And pattern 1 is the weak one - the
+corpus attests 1.2x, not 8x. The case for the cache is that it costs a consumer who does not
+want it nothing, because `NoCache` is the default and only `cached_object` consults it
+([section 4.4](#s4.4), rule S14), while paying 8x for the interactive consumers ADR-0011 names.

--- a/docs/design/bin-streaming.md
+++ b/docs/design/bin-streaming.md
@@ -119,11 +119,16 @@ Every term this document uses in a specific sense.
 
 ## <a id="s4"></a>4. API surface - `PROP`
 
-All types live in `ltk_meta::stream` and are re-exported from the crate root. Signatures are
-the design; doc comments are abbreviated. `M` is the same property-meta parameter the eager
-types carry, defaulting to `NoMeta`, and lives on the handle: `concrete` grows `BinStream`,
-`BinOverrideStream` and `BinFileStream` aliases that pin it at the `mount` call, after which
-it disappears from every downstream signature (ADR-0010).
+All types live in `ltk_meta::stream` and are re-exported in full from the crate root, which is
+where a consumer names them. Signatures are the design; doc comments are abbreviated. `M` is the
+same property-meta parameter the eager types carry, defaulting to `NoMeta`, and lives on the handle
+(ADR-0010) - the only placement a `concrete` alias can reach. The alias is what removes the
+annotation, because `mount` is itself expression position and Rust applies no default there:
+`concrete::BinStream::mount(file)` pins `M`, which then disappears from every downstream signature.
+So `concrete` carries the expression-position names of the shipped surface - `BinStream`,
+`LruObjectCache` and its `NoCache` sibling - while every other type is named in type position,
+where the default applies. The `PTCH` handles of [section 5](#s5) want the same alias when they
+land.
 
 ```rust
 /// A mounted `PROP` stream: the header is parsed, the object table is read on demand.
@@ -873,7 +878,7 @@ rules append.
 | S9 | `Bin::from_reader` is `mount` plus `into_bin`. | Keeping the eager reader as its own parser. | Makes the stream the crate's only parser, so a fix to one is a fix to both. | [section 9](#s9); ADR-0008 |
 | S10 | The layout module is crate-internal; only `Numbering` is re-exported. | Publishing the cursor. | Nothing outside the crate uses it, and publishing a thirty-method cursor pins it under semver for nobody's benefit. | [section 9](#s9) |
 | S11 | Counts drive the parse, declared sizes drive the skips, and a size the walk disagrees with is `Error::InvalidSize`. | A tolerant discrepancy log, as the client is tolerant. | Continuing past the mismatch means handing out TOC rows and byte ranges built from sizes the parse just disproved. | [section 7](#s7); ADR-0009 |
-| S12 | `M` lives on the handle, pinned once through a `concrete` alias. | `M` on the value-producing methods. | Rust never applies a type parameter's default in expression position, so a method-level `M` needs a turbofish at every call site and `concrete` cannot reach it. | [section 4](#s4); ADR-0010 |
+| S12 | `M` lives on the handle, and a `concrete` alias pins it at the `mount` call. | `M` on the value-producing methods. | Handle placement is the only one an alias can reach, and the alias is what a consumer depends on, because `mount` is itself expression position. | [section 4](#s4); ADR-0010 |
 | S13 | The public error enums are `#[non_exhaustive]`, taken in the 0.8.0 breaking window. | Adding variants as breaking changes later. | The streaming work grows variants for years; the free breaking moment was the one to spend. | `ptch-property-patches.md` [section 6](ptch-property-patches.md#s6) |
 | S14 | Caching is an opt-in provider on the handle, `NoCache` by default, returning `Arc<BinObject<M>>`. Only `cached_object()` consults it. | An `Option<Cache>` returning a borrow, or a policy enum and a third type parameter. | Eviction must never invalidate a value a caller holds, and a sweep must not evict what a consumer is holding hot. | [section 4.4](#s4.4); ADR-0011 |
 | S15 | The latch re-reads the current object under legacy numbering, then latches for the handle's life; `into_bin` restarts from the top. | Re-reading the whole file, as the eager reader does, on every discovery. | With buffered objects the retry is a re-walk of bytes already in memory. Restarting `into_bin` is what keeps the eager path's behaviour identical. | [section 8](#s8) |

--- a/docs/prd/002-streaming-bin-reading.md
+++ b/docs/prd/002-streaming-bin-reading.md
@@ -129,7 +129,12 @@ Facts the format imposes, read off the client's loader
 - **Parallel access within one file.** One cursor at a time per handle, `&mut self` throughout. The
   fan-out workloads parallelize per file.
 - **Caching by default.** The uncached paths parse on every call; caching is the opt-in provider of
-  FR-10.
+  FR-10, and measurement says that split is the right one. A hit is 286x cheaper than a miss, but
+  the only access pattern a shipped install attests - an editor chasing links - revisits little
+  enough to buy 1.2x, while a re-requested working set buys 8.3x. The payoff is the consumer's hit
+  rate rather than the crate's, which is what makes `NoCache` the right default and caching the
+  wrong thing to impose: `bin-streaming.md` [appendix B](../design/bin-streaming.md#appendix-b) has
+  the numbers and the method.
 
 ## <a id="s8"></a>8. Acceptance
 


### PR DESCRIPTION
The bin-streaming reader is merged and unreleased. Before it ships, two gaps in its
public surface are worth closing, because both are compiler-proven rather than a
matter of taste, and neither can be fixed later without a second version bump.

## The root under-exported `stream`

`stream` publishes twenty-one names; the root re-exported eleven. `ValueView` was
among them but `ContainerView`, `MapView`, `StructView` and `OptionalView` — the four
you reach by matching on it — were not, so every real walk imported from two places.

The root now mirrors the module's own `pub use` list. This is what
[section 4](https://github.com/LeagueToolkit/league-toolkit/blob/main/docs/design/bin-streaming.md#s4)
already claimed ("re-exported from the crate root") and what #207 promised, so it
closes a gap rather than opening a question. No collisions: `tree`, `error`, `file`
and `data_override` share none of the ten new names.

## `concrete` carries what Rust cannot infer

A type parameter's default applies in type position but never in expression position.
That makes `concrete::BinStream` load-bearing rather than a convenience:

```rust
let mut stream = ltk_meta::BinStream::mount(File::open(path)?)?;
// error[E0283]: type annotations needed for `BinStream<File, _>`
```

`LruObjectCache::new` is the same case, so it joins it. `NoCache` is re-exported
rather than aliased, because an associated function resolves through a type alias
but a unit struct's value constructor does not.

The views are deliberately **not** aliased. They are only ever named in type
position, where the default already applies, so the root re-export above is enough —
a second path would rebuild the two-import-site problem this removes.

## One trait was missing its default

`ObjectCache` was the only type in the module without `M = NoMeta`. A consumer
holding a policy in a struct field had no inference to lean on and had to write
`Box<dyn ObjectCache<NoMeta> + Send>`, importing `NoMeta` from a third path. It now
carries the default the rest of the surface has. Nothing published contains this
trait, so it costs no compatibility.

## Guard

`tests/import_surface.rs` names every streaming type from the root or `concrete` and
nowhere else, mounts with no turbofish and no annotation, names the four sub-views in
type position, and holds a cache policy in a struct field. It asserts real fixture
content, so it fails on a lost export and on a lost default, not merely on a
rename.

## Docs

Section 4 read as though moving `M` onto the handle resolved the annotation problem.
It does not — `mount` is expression position — and it promised `concrete` aliases for
two types that do not exist. Both corrected in place; S12 keeps its ID; ADR-0010 is
untouched and still carries the argument.

#210, #211 and #217 are parked with the evidence against each rather than with
"later". All three stay open.

## Verification

`cargo fmt --all --check`, `cargo clippy -p ltk_meta --all-targets -- -D warnings`,
`cargo test --workspace` and `cargo doc -p ltk_meta --no-deps` (under
`RUSTDOCFLAGS="-D warnings"`) all clean.

Also here, as a separate `chore:` commit: `cargo clippy --workspace --all-targets -- -D warnings`
was failing at `crates/ltk_anim/src/rig/write.rs:71` on `unnecessary_sort_by` — a clippy 1.97
regression in a file untouched since 2025-09-26, so `main` was already red. `sort_by_key` with
`Reverse` is the same stable descending sort by the same key, so the bytes written do not move.
It is `chore` rather than `fix` on purpose: nothing was broken for a user, and `release_commits`
would read `fix` as reason to cut an `ltk_anim` release this does not warrant. The workspace
clippy gate is now green.
